### PR TITLE
Improve range parsing

### DIFF
--- a/spec/range-spec.coffee
+++ b/spec/range-spec.coffee
@@ -1,5 +1,6 @@
 assert = require('chai').assert
 range = require('../src/range')
+number = require('../src/number')
 
 
 describe 'Range', ->
@@ -49,7 +50,7 @@ describe 'Range', ->
     assert.isNull r.avg
     assert.isTrue r.valid
 
-  it 'should support single integer', ->
+  it 'should support single integer string', ->
     r = range.parse '10'
     assert.equal r.toString(), '10'
     assert.equal r.raw, '10'
@@ -58,8 +59,26 @@ describe 'Range', ->
     assert.equal r.avg, 10
     assert.isTrue r.valid
 
-  it 'should support single decimal', ->
+  it 'should support single integer', ->
+    r = range.parse 10
+    assert.equal r.toString(), '10'
+    assert.equal r.raw, '10'
+    assert.equal r.min, 10
+    assert.equal r.max, 10
+    assert.equal r.avg, 10
+    assert.isTrue r.valid
+
+  it 'should support single decimal strings', ->
     r = range.parse '5.5'
+    assert.equal r.toString(), '5.5'
+    assert.equal r.raw, '5.5'
+    assert.equal r.min, 5.5
+    assert.equal r.max, 5.5
+    assert.equal r.avg, 5.5
+    assert.isTrue r.valid
+
+  it 'should support single decimal strings', ->
+    r = range.parse 5.5
     assert.equal r.toString(), '5.5'
     assert.equal r.raw, '5.5'
     assert.equal r.min, 5.5
@@ -148,3 +167,11 @@ describe 'Range', ->
     assert.equal r.avg, 5.5
     assert.isTrue r.valid
 
+  it 'should parse a parsed number', ->
+    r = range.parse(number.parse('4'))
+    assert.equal r.toString(), '4'
+    assert.equal r.raw, '4'
+    assert.equal r.min, 4
+    assert.equal r.max, 4
+    assert.equal r.avg, 4
+    assert.isTrue r.valid

--- a/src/range.coffee
+++ b/src/range.coffee
@@ -28,7 +28,7 @@ parse = (string) ->
     if _(min).isNumber() and _(max).isNumber()
       parsed = new String("#{min}-#{max}")
       parsed.raw = raw
-      parsed.avg = ((min + max) / 2).toFixed(2)
+      parsed.avg = parseFloat(((min + max) / 2).toFixed(2))
       parsed.min = min
       parsed.max = max
     else if _(min).isNumber()

--- a/src/range.coffee
+++ b/src/range.coffee
@@ -8,6 +8,9 @@ rangeRegex = named /(:<min>\d+(?:\.\d+)?)\s+(:<max>\d+(?:\.\d+)?)/
 parse = (string) ->
   return string unless string?
 
+  # Don't re-parse parsed ranges, overwriting the original raw value
+  string = string.toString() unless string.replace?
+
   # Sanitize the string the remove non-numeric characters. The rangeRegex relies on this
   # sanitization routine in order to match range strings
   #  * replace '-' and 'to' with a space


### PR DESCRIPTION
Fixing a few bugs for range parsing:

- Allow parsing of objects that don't have a `replace` property. Especially useful when parsing number types
- Ensure that the `avg` property is a number type