### PR TITLE
Ensure dynamic postal code properties are saved as null

### DIFF
--- a/spec/postal-code-spec.coffee
+++ b/spec/postal-code-spec.coffee
@@ -9,7 +9,7 @@ describe 'Postal code', ->
     assert.equal pc.toString(), '78704'
     assert.equal pc.raw, '  78704  '
     assert.equal pc.zip, '78704'
-    assert.isUndefined pc.four
+    assert.isNull pc.four
     assert.equal pc.country_code, 'US'
     assert.isTrue pc.valid
 
@@ -18,7 +18,7 @@ describe 'Postal code', ->
     assert.equal pc.toString(), '78704'
     assert.equal pc.raw, '78704'
     assert.equal pc.zip, '78704'
-    assert.isUndefined pc.four
+    assert.isNull pc.four
     assert.equal pc.country_code, 'US'
     assert.isTrue pc.valid
       

--- a/src/postal-code.coffee
+++ b/src/postal-code.coffee
@@ -32,7 +32,7 @@ parse = (string) ->
       parsed.raw = string.raw ? string
       parsed.country_code = region
       for key, value of captures
-        parsed[key] = value?.toUpperCase()
+        parsed[key] = value?.toUpperCase() ? null
       parsed.valid = true
       return parsed
 


### PR DESCRIPTION
A recent bson serialization change
(https://jira.mongodb.org/browse/NODE-517) omits object properties that
have an undefined value. This change ensures that undefined postal code
values are saved as null, so that they persist.