### PR TITLE
add tests for 'date' and 'time' to ensure they can parse a Date object

### DIFF
--- a/spec/date-spec.coffee
+++ b/spec/date-spec.coffee
@@ -47,6 +47,16 @@ describe 'Date', ->
     assert.equal parsed.valueOf(), '2014-06-02'
     assert.equal parsed.raw, 'Mon Jun 02 2014'
 
+  it 'should handle parsing a JavaScript date', ->
+    now = new Date(2015, 10, 6) # 0-based month index :-/
+    parsed = date.parse(now)
+    assert.instanceOf parsed, Date
+    assert.deepEqual parsed, now
+    assert.isTrue parsed.valid
+    assert.equal parsed.toString(), '2015-11-06'
+    assert.equal parsed.valueOf(), '2015-11-06'
+    assert.equal parsed.raw, now
+
   it 'should have examples', ->
     assert date.examples.length
 

--- a/spec/time-spec.coffee
+++ b/spec/time-spec.coffee
@@ -50,3 +50,12 @@ describe 'Time', ->
     assert.equal date.raw, '06/14/2014 6:27:33 PM'
     assert.isTrue date.valid
 
+  it 'should handle parsing a JavaScript date', ->
+    now = new Date(2015, 10, 6, 11, 47, 42) # 0-based month index :-/
+    parsed = time.parse(now)
+    assert.instanceOf parsed, Date
+    assert.deepEqual parsed, now
+    assert.isTrue parsed.valid
+    assert.equal parsed.toString(), '2015-11-06T11:47:42.000Z'
+    assert.equal parsed.valueOf(), '2015-11-06T11:47:42.000Z'
+    assert.equal parsed.raw, now


### PR DESCRIPTION
@alexkwolfe re: [this comment](https://github.com/activeprospect/leadconduit-integration-leadid/pull/1#discussion_r44064764), is this the test coverage you were suggesting?