### PR TITLE
Add raw property to credential parser output

### DIFF
--- a/spec/credential-spec.coffee
+++ b/spec/credential-spec.coffee
@@ -21,5 +21,9 @@ describe 'Credential', ->
     assert.isFalse credential.parse('hi').masked
 
 
+  it 'should retain raw value', ->
+    assert.equal credential.parse('hi').raw, 'hi'
+
+
   it 'should have examples', ->
     assert credential.examples.length

--- a/src/credential.coffee
+++ b/src/credential.coffee
@@ -3,6 +3,7 @@ normalize = require('./normalize')
 parse = (string) ->
   return string unless string?
   parsed = new String(string)
+  parsed.raw = string.raw ? string
   parsed.masked = false
   parsed.valid = true
   parsed


### PR DESCRIPTION
This will fix [this API issue](https://github.com/activeprospect/leadconduit-api/issues/216)