### PR TITLE
Remove 'string' operators 'includes' & 'does not include'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.9.1] - 2016-08-30
+### Removed
+- Remove unneeded `string` operators `includes` & `does not include` (issue #44)
+
 ## [4.9.0] - 2016-07-11
 ### Fixed
 - Add support for negative range minimums (_only;_ not maximums), including dates prior to Jan. 1, 1970

--- a/src/string.coffee
+++ b/src/string.coffee
@@ -13,8 +13,6 @@ module.exports =
     'is not equal to'
     'is blank'
     'is not blank'
-    'includes'
-    'does not include'
     'is included in'
     'is not included in'
   ]


### PR DESCRIPTION
Fixes #44. 

I don't think this will affect lead handling, if flows have rules
in place testing 'string' values with these operators. It will
cause validation warnings on those flows the next time they're
saved.