### PR TITLE
fix problem of parsing non-type types (e.g., array)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.11.2] - 2016-10-25
+### Fixed
+- fix bug where 'array'-type data was being mistakenly parsed
+
 ## [4.11.1] - 2016-10-25
 ### Fixed
 - change example text for strings to 'any text' (issue #47)

--- a/spec/index-spec.coffee
+++ b/spec/index-spec.coffee
@@ -15,6 +15,9 @@ describe 'Index', ->
 
     assert.deepEqual index.names, expectedTypeNames
 
+  it 'should not try to parse an non-type (e.g., array)', ->
+    parsed = index.parse 'array', [1, 3, 5]
+    assert.deepEqual parsed, [1, 3, 5]
 
   it 'should not parse a value twice', ->
     parsed = index.parse 'phone', '5127891111'

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -14,15 +14,15 @@ module.exports.aggregate = aggregate
 
 module.exports.parse = (name, value, req) ->
   # Look up the type of the field, based on its name
-  type = module.exports[name] if typeNames.indexOf(name) != -1
+  fieldType = module.exports[name] if typeNames.indexOf(name) != -1
 
-  if type? and value?
-    if type.components?.length and value.valid?
+  if fieldType? and value?
+    if fieldType.components?.length and value.valid?
       # the value already has components, so parsing isn't necessary
       return value
     else
       # call its parse function and set the new value
-      type.parse value, req
+      fieldType.parse value, req
   else
     value
 


### PR DESCRIPTION
this came up after a deploy today, an integration of 360's that
appends 'array'-type data started stringifying the array
('[object Object],[object Object],...'). Turned out to be caused
by the variable 'type' now being declared on line 9 of
index.coffee, which kept its last value and caused the conditional
'type?' on line 19 to incorrectly be true.
(line numbers reference [previous version of index.coffee](https://github.com/activeprospect/leadconduit-types/blob/d4d1cb6eee9fdc0d25145242269df904364a4843/src/index.coffee))