### PR TITLE
Aggregate time and date types as strings

### DIFF
--- a/spec/aggregate-spec.coffee
+++ b/spec/aggregate-spec.coffee
@@ -1,4 +1,5 @@
 assert = require('chai').assert
+moment = require('moment')
 types = require('../src')
 aggregate = require('../src/aggregate')
 
@@ -199,3 +200,37 @@ describe 'SSN aggregation', ->
 
   it 'should not be aggregated', ->
     assert.isUndefined ssn
+
+
+
+describe 'Time aggregation', ->
+
+  time = null
+  expected = null
+
+  beforeEach ->
+    expected = new Date().toISOString()
+    vars = types.normalize(timestamp: types.parse('time', expected))
+    fieldTypes = timestamp: 'time'
+    time = aggregate(vars, fieldTypes).timestamp
+
+
+  it 'should aggregate as normal value', ->
+    assert.equal time, expected
+
+
+
+describe 'Date aggregation', ->
+
+  date = null
+  expected = null
+
+  beforeEach ->
+    expected = moment().format('YYYY-MM-DD')
+    vars = types.normalize(dob: types.parse('date', expected))
+    fieldTypes = dob: 'date'
+    date = aggregate(vars, fieldTypes).dob
+
+
+  it 'should aggregate as normal value', ->
+    assert.equal date, expected

--- a/src/aggregations/date.coffee
+++ b/src/aggregations/date.coffee
@@ -1,0 +1,6 @@
+moment = require('moment')
+
+module.exports = (date) ->
+  return unless date?.valid == true
+  return unless date.normal?
+  moment(date.normal).format('YYYY-MM-DD')

--- a/src/aggregations/time.coffee
+++ b/src/aggregations/time.coffee
@@ -1,0 +1,3 @@
+module.exports = (time) ->
+  return unless time?.valid == true
+  time.normal?.toISOString()


### PR DESCRIPTION
I missed adding logic for time and date aggregations. This PR takes care of that.