### PR TITLE
fix date parsing: unescape value; & parse dd/mm/yyyy when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.14.1] - 2017-03-15
+## Added
+- logging of when "strict" date-parsing fails
+
 ## [4.14.0] - 2017-01-23
 ## Added
 - add Canada provinces to `state` type (fixes #87)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "description": "A Node.JS module that parses data by type",
   "version": "4.14.0",
   "main": "lib/index",
+  "license": "CC-BY-NC-ND-4.0",
+  "repository": "https://github.com/activeprospect/leadconduit-types",
   "scripts": {
     "test": "cake test",
     "prepublish": "cake build"
@@ -17,7 +19,7 @@
     "handlebars": "^2.0.0-alpha.4",
     "libphonenumber": "0.0.x",
     "lodash": "^4.16.2",
-    "moment": "^2.6.0",
+    "moment": "^2.14.0",
     "named-regexp": "^0.1.1"
   },
   "devDependencies": {

--- a/spec/date-spec.coffee
+++ b/spec/date-spec.coffee
@@ -61,5 +61,3 @@ describe 'Date', ->
 
   it 'should have examples', ->
     assert date.examples.length
-
-

--- a/src/types/date.coffee
+++ b/src/types/date.coffee
@@ -11,9 +11,14 @@ formats = [
   'MMDDYYYY'        # '06022014'
 ]
 
-parse = (string) ->
+parse = (string, req) ->
   raw = string.raw ? string
-  results = moment(string.toString(), formats)
+  results = moment(string.toString(), formats, true)
+
+  if !results.isValid()
+    # strict mode parsing failed; log what failed and try again in forgiving mode [todo: this is temporary! 3/17]
+    results = moment(string.toString(), formats)
+    req?.logger?.info "strict mode date-parsing failed for [#{string}]; forgiving mode gave: #{results.toString()}"
 
   if results.isValid()
     parsed = results.toDate()


### PR DESCRIPTION
AP support reported [an issue in Slack today](https://activeprospect.slack.com/archives/support/p1489583948461145), where a `dob` value of `14%2F03%2F1985` was being parsed as "March 19, 2014" (vs. "March 14, 1985").

When I investigated I found two problems: the encoded `/`s were confusing the `moment.js` parser, and there was no pattern to parse "DD/MM/YYYY". This PR includes fixes and additional test coverage. 