### PR TITLE
add two date formats and change one, on the way to strict parsing

### DIFF
--- a/spec/date-spec.coffee
+++ b/spec/date-spec.coffee
@@ -7,9 +7,12 @@ describe 'Date', ->
     'Mon Jun 02 2014'
     'Jun 02 2014'
     '06/02/2014'
+    '6/2/2014'
+    '6/2/14'
     '2014-06-02'
     '06-02-2014'
     '06022014'
+    '20140602'
   ]
 
   for string in strings
@@ -49,15 +52,6 @@ describe 'Date', ->
     assert.equal parsed.valueOf(), '2014-06-02'
     assert.equal parsed.raw, 'Mon Jun 02 2014'
 
-  it 'should handle parsing a JavaScript date', ->
-    now = new Date(2015, 10, 6) # 0-based month index :-/
-    parsed = date.parse(now)
-    assert.instanceOf parsed, Date
-    assert.deepEqual parsed, now
-    assert.isTrue parsed.valid
-    assert.equal parsed.toString(), '2015-11-06'
-    assert.equal parsed.valueOf(), '2015-11-06'
-    assert.equal parsed.raw, now
-
   it 'should have examples', ->
     assert date.examples.length
+

--- a/src/types/date.coffee
+++ b/src/types/date.coffee
@@ -5,10 +5,12 @@ normalize = require('../normalize')
 formats = [
   'ddd MMM DD YYYY' # 'Mon Jun 02 2014'
   'MMM DD YYYY'     # 'Jun 02 2014'
-  'MM/DD/YYYY'      # '06/02/2014'
+  'M/D/YYYY'        # '6/2/2014', '06/02/2014'
+  'M/D/YY'          # '6/2/14'
   'YYYY-MM-DD'      # '2014-06-02'
   'MM-DD-YYYY'      # '06-02-2014'
   'MMDDYYYY'        # '06022014'
+  'YYYYMMDD'        # '06022014'
 ]
 
 parse = (string, req) ->


### PR DESCRIPTION
After analyzing data from 3/16-3/20, these slight changes to allowed formats addressed nearly all the strict-parsing failures. 

I say "nearly all" because there were some that included a trailing timestamp which still failed parsing, but I found that those were all Ralis/Cashcall inbound, so I added code there ([PR 46](https://github.com/activeprospect/leadconduit-integration-cashcall/pull/46)) to ensure those were still parsed correctly. 