### PR TITLE
Support euro dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.17.0] - 2018-09-26
+## Fixed
+- Support European date formats
+
 ## [4.16.2] - 2018-02-16
 ## Fixed
 - corrected state abbreviations (#108)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [4.17.0] - 2018-09-26
 ## Fixed
-- Support European date formats
+- Support European date formats (https://activeprospect.tpondemand.com/entity/4350-leadconduit-does-not-properly-parse-dates)
 
 ## [4.16.2] - 2018-02-16
 ## Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -705,7 +705,7 @@
     },
     "minimist": {
       "version": "0.0.10",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "mkdirp": {
@@ -776,9 +776,9 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "ms": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -658,9 +658,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "markdown-pdf": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "flat": "^2.0.1",
     "google-libphonenumber": "^3.0.0",
     "handlebars": "^4.0.0",
-    "lodash": "^4.16.2",
+    "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "named-regexp": "^0.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
     "prepublish": "cake build"
   },
   "dependencies": {
+    "@activeprospect/freemail": "^1.5.0",
     "@activeprospect/indexer": "^1.3.1",
     "chrono-node": "git://github.com/alexkwolfe/chrono.git#milliseconds",
     "domain-name-parser": "0.0.4",
     "email-addresses": "^1.1.1",
     "faker": "^3.0.1",
     "flat": "^2.0.1",
-    "@activeprospect/freemail": "^1.5.0",
     "google-libphonenumber": "^3.0.0",
     "handlebars": "^4.0.0",
     "lodash": "^4.16.2",
-    "moment": "^2.14.0",
+    "moment": "^2.22.2",
     "named-regexp": "^0.1.1"
   },
   "devDependencies": {

--- a/spec/date-spec.coffee
+++ b/spec/date-spec.coffee
@@ -15,6 +15,18 @@ describe 'Date', ->
     '20140602'
   ]
 
+  euroStrings = [
+    'Mon 18 July 2014'
+    '18 July 2014'
+    '18/07/2014'
+    '18/7/2014'
+    '18/7/14'
+    '2014-18-07'
+    '18-07-2014'
+    '18072014'
+    '20141807'
+  ]
+
   for string in strings
 
     do (string) ->
@@ -37,6 +49,27 @@ describe 'Date', ->
         it 'should be valid', ->
           assert.isTrue date.parse(string).valid
 
+  for string in euroStrings
+
+    do (string) ->
+
+      describe string, ->
+
+        it 'should return a Date object', ->
+          parsed = date.parse string
+          assert.instanceOf parsed, Date
+          assert.equal parsed.toISOString(), '2014-07-18T00:00:00.000Z'
+
+        it 'should have string value', ->
+          parsed = date.parse string
+          assert.equal parsed.toString(), '2014-07-18'
+          assert.equal parsed.valueOf(), '2014-07-18'
+
+        it 'should have raw value', ->
+          assert.equal date.parse(string).raw, string
+
+        it 'should be valid', ->
+          assert.isTrue date.parse(string).valid
 
   it 'should not parse garbage', ->
     parsed = date.parse 'garbage'
@@ -54,4 +87,3 @@ describe 'Date', ->
 
   it 'should have examples', ->
     assert date.examples.length
-

--- a/src/types/date.coffee
+++ b/src/types/date.coffee
@@ -11,7 +11,18 @@ formats = [
   'MM-DD-YYYY'      # '06-02-2014'
   'MMDDYYYY'        # '06022014'
   'YYYYMMDD'        # '06022014'
+
+  # European formats (month first)
+  'ddd DD MMM YYYY'   # 'Mon Jun 02 2014'
+  'DD MMM YYYY'       # '18 July 2014'
+  'D/M/YYYY'          # '18/7/2014'
+  'D/M/YY'            # '18/7/14'
+  'YYYY-DD-MM'        # '2014-18-07'
+  'DD-MM-YYYY'        # '18-07-2014'
+  'DDMMYYYY'          # '18072014'
+  'YYYY-DD-MM'        # '2014-18-07' 
 ]
+
 
 parse = (string, req) ->
   raw = string.raw ? string


### PR DESCRIPTION
This PR supports European date formats (day before month).

From the Moment [docs](https://momentjs.com/docs/#/parsing/string-formats/):
> Moment uses some simple heuristics to determine which format to use. In order:
>>Prefer formats resulting in valid dates over invalid ones.
>>Prefer formats that parse more of the string than less and use more of the format than less, i.e. prefer stricter parsing.
>>Prefer formats earlier in the array than later.

European formats were _appended_ to the `formats` array, so the Date type should prefer non-euro formats (all things being equal).

[TP Ticket](https://activeprospect.tpondemand.com/restui/board.aspx?#page=bug/4350) for more context.