### PR TITLE
TrustedForm URL now supports staging URLs

### DIFF
--- a/lib/types/trustedform_url.js
+++ b/lib/types/trustedform_url.js
@@ -8,7 +8,7 @@ const parse = function (str) {
   const parsed = urlType.parse(str);
   if (!parsed.valid) return failure(parsed);
   const insecureProtocol = parsed.protocol !== 'https';
-  const invalidHost = !parsed.host.match(/(cert|ping)\.trustedform\.com/);
+  const invalidHost = !parsed.host.match(/(cert|ping)\.(staging\.)?trustedform\.com/);
   let id = getIdFromPath(parsed.path);
   if (insecureProtocol || invalidHost || !id) {
     return failure(parsed);

--- a/test/trustedform-url.test.js
+++ b/test/trustedform-url.test.js
@@ -41,6 +41,18 @@ describe('TrustedForm URL', function () {
     assert.equal(parsed.cert_id, '0.vzhYBmGsqsu4ob7u4rWDOX6Gg4OT5SAza1r%2FTYNMJ81Kx%2FFGh2SZGtlZ7KiEg7lEdxi7xLcq.15GK4f1R9Te6Rjd4J85Xng.Bdz5CUNsDpelrvmW0L9sQg');
   });
 
+  it('should handle staging URLs', function() {
+    const tests = [
+      'https://cert.staging.trustedform.com/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947',
+      'https://ping.staging.trustedform.com/0.1JT7QUPI1sOFZxpr72ZK45K0ck75kEBO9H3jNJuX8NkqMTv4UF-zrapBUlsefTP3lkXWh6qM.fF0DNrov0zNUNVRCqDV5dw.E2eYOJ5-dnAgiX02-96FNQ'
+    ]
+    for(test of tests) {
+      const parsed = url.parse(test);
+      assert.equal(parsed.raw, test);
+      assert.isTrue(parsed.valid);
+    }
+  });
+
   describe('invalid values', function () {
     it('should handle non-TF URLs', function() {
       const testUrl = 'https://activeprospect.com';


### PR DESCRIPTION
## Description of the change

TrustedForm URL type now supports URLs using staging host names.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

[Shortcut #37183](https://app.shortcut.com/active-prospect/story/37183/allow-a-trustedform-ping-url-to-be-passed-in-the-trustedfrom-cert-url-field-of-trustedform-data-service-integration)

## Checklists

### Development and Testing

- [X]  Lint rules pass locally.
- [X]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [X]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
