### PR TITLE
Support checking cert host name for dev environment and make sure cert env matches server env

### DIFF
--- a/lib/types/trustedform_url.js
+++ b/lib/types/trustedform_url.js
@@ -1,14 +1,13 @@
 const moment = require('moment');
 const {decrypt, ping} = require('@activeprospect/trustedform-cert-id');
 const urlType = require('./url');
-const normalize = require('../normalize');
 
 const parse = function (str) {
   if (!str) return str;
   const parsed = urlType.parse(str);
   if (!parsed.valid) return failure(parsed);
   const insecureProtocol = parsed.protocol !== 'https';
-  const invalidHost = !parsed.host.match(/(cert|ping)\.(staging\.)?trustedform\.com/);
+  const invalidHost = !isHostValid(parsed.host)
   let id = getIdFromPath(parsed.path);
   if (insecureProtocol || invalidHost || !id) {
     return failure(parsed);
@@ -37,6 +36,33 @@ const parse = function (str) {
   rtn.valid = age <= 90;
   return rtn;
 };
+
+const isHostValid = (host) => {
+  if (!host) return false;
+  const certEnv = determineEnv(host)
+  if (!certEnv) {
+    return false;
+  }
+  const serverEnv = process.env.NODE_ENV;
+  if (!serverEnv) {
+    return true;
+  }
+  return certEnv === serverEnv;
+}
+
+const determineEnv = (host) => {
+  if (host.match(/(cert|ping)\.trustedform\.com/)) {
+    return 'production';
+  } else if (host.match(/(cert|ping)\.staging\.trustedform\.com/) || host.match(/(cert|ping)\.trustedform-staging\.com/)) {
+    return 'staging';
+  } else if (host.match(/(cert|ping)\.trustedform-dev\.com/)) {
+    return 'development';
+  } else if (host.match(/(cert|ping)\.trustedform\.localhost/)) {
+    return 'local';
+  } else {
+    return null;
+  }
+}
 
 const getPingUrl = (id, cert) => {
   if (cert.isPing) {

--- a/test/trustedform-url.test.js
+++ b/test/trustedform-url.test.js
@@ -10,7 +10,7 @@ const url = require('../lib/types/trustedform_url');
 const regularUrl = require('../lib/types/url');
 const certId = require('@activeprospect/trustedform-cert-id');
 
-describe('TrustedForm URL', function () {
+describe.only('TrustedForm URL', function () {
   it('should not parse null', function () {
     assert.isNull(url.parse(null));
   });
@@ -44,13 +44,63 @@ describe('TrustedForm URL', function () {
   it('should handle staging URLs', function() {
     const tests = [
       'https://cert.staging.trustedform.com/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947',
-      'https://ping.staging.trustedform.com/0.1JT7QUPI1sOFZxpr72ZK45K0ck75kEBO9H3jNJuX8NkqMTv4UF-zrapBUlsefTP3lkXWh6qM.fF0DNrov0zNUNVRCqDV5dw.E2eYOJ5-dnAgiX02-96FNQ'
+      'https://cert.trustedform-staging.com/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947',
+      'https://ping.staging.trustedform.com/0.1JT7QUPI1sOFZxpr72ZK45K0ck75kEBO9H3jNJuX8NkqMTv4UF-zrapBUlsefTP3lkXWh6qM.fF0DNrov0zNUNVRCqDV5dw.E2eYOJ5-dnAgiX02-96FNQ',
+      'https://ping.trustedform-staging.com/0.1JT7QUPI1sOFZxpr72ZK45K0ck75kEBO9H3jNJuX8NkqMTv4UF-zrapBUlsefTP3lkXWh6qM.fF0DNrov0zNUNVRCqDV5dw.E2eYOJ5-dnAgiX02-96FNQ'
     ]
     for(test of tests) {
       const parsed = url.parse(test);
       assert.equal(parsed.raw, test);
       assert.isTrue(parsed.valid);
     }
+  });
+
+  it('should handle dev URLs', function() {
+    const tests = [
+      'https://cert.trustedform-dev.com/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947',
+      'https://ping.trustedform-dev.com/0.1JT7QUPI1sOFZxpr72ZK45K0ck75kEBO9H3jNJuX8NkqMTv4UF-zrapBUlsefTP3lkXWh6qM.fF0DNrov0zNUNVRCqDV5dw.E2eYOJ5-dnAgiX02-96FNQ'
+    ]
+    for(test of tests) {
+      const parsed = url.parse(test);
+      assert.equal(parsed.raw, test);
+      assert.isTrue(parsed.valid);
+    }
+  });
+
+  it('should handle local URLs', function() {
+    const tests = [
+      'https://cert.trustedform.localhost/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947',
+      'https://ping.trustedform.localhost/0.1JT7QUPI1sOFZxpr72ZK45K0ck75kEBO9H3jNJuX8NkqMTv4UF-zrapBUlsefTP3lkXWh6qM.fF0DNrov0zNUNVRCqDV5dw.E2eYOJ5-dnAgiX02-96FNQ'
+    ]
+    for(test of tests) {
+      const parsed = url.parse(test);
+      assert.equal(parsed.raw, test);
+      assert.isTrue(parsed.valid);
+    }
+  });
+
+  describe('environment', function () {
+    beforeEach(function() {
+      this.env = process.env.NODE_ENV;
+    });
+
+    afterEach(function() {
+      process.env.NODE_ENV = this.env;
+    });
+
+    it('should not allow staging urls in production env', function() {
+      process.env.NODE_ENV = 'production';
+      const test = 'https://cert.trustedform.staging.com/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947';
+      const parsed = url.parse(test);
+      assert.isFalse(parsed.valid);
+    });
+
+    it('should not allow dev urls in production env', function() {
+      process.env.NODE_ENV = 'production';
+      const test = 'https://cert.trustedform-dev.com/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947';
+      const parsed = url.parse(test);
+      assert.isFalse(parsed.valid);
+    });
   });
 
   describe('invalid values', function () {

--- a/test/trustedform-url.test.js
+++ b/test/trustedform-url.test.js
@@ -10,7 +10,7 @@ const url = require('../lib/types/trustedform_url');
 const regularUrl = require('../lib/types/url');
 const certId = require('@activeprospect/trustedform-cert-id');
 
-describe.only('TrustedForm URL', function () {
+describe('TrustedForm URL', function () {
   it('should not parse null', function () {
     assert.isNull(url.parse(null));
   });

--- a/test/trustedform-url.test.js
+++ b/test/trustedform-url.test.js
@@ -90,7 +90,7 @@ describe('TrustedForm URL', function () {
 
     it('should not allow staging urls in production env', function() {
       process.env.NODE_ENV = 'production';
-      const test = 'https://cert.trustedform.staging.com/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947';
+      const test = 'https://cert.staging.trustedform.com/eb9fc4dd9bed9ad451a5648946cf4bf09b5bb947';
       const parsed = url.parse(test);
       assert.isFalse(parsed.valid);
     });


### PR DESCRIPTION
## Description of the change

This PR performs deeper checking of the host name portion of the TrustedForm URL. It now supports development certs and ensures that the env of the cert's host name matches the env of the running server process. This last check ensures that we don't try to decrypt a production cert with the staging private key.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

[Shortcut #37783](https://app.shortcut.com/active-prospect/story/37783/trustedform-cert-url-type)

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
