### PR TITLE
Stop logging to datadot unparsable phone numbers

### DIFF
--- a/lib/types/phone.js
+++ b/lib/types/phone.js
@@ -89,7 +89,6 @@ const resolve = function (string, logger) {
     try {
       number = phoneUtil.parse(string, regionCode);
     } catch (e) {
-      if (logger) { logger.error(e); }
       number = null;
     }
     if (number != null) { break; }


### PR DESCRIPTION
## Description of the change

Removes the code which sends DataDog messages about an inability to log unparsable phone numbers.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

[Stop Spamming DataDog with Phone Number Errors](https://app.shortcut.com/active-prospect/story/38267/stop-spamming-datadog-with-phone-number-errors)

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [x]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [x]  This branch has been deployed to staging and tested.
