### PR TITLE
This test case was failing due to the new version of trustedform-cert-id@1.1.4

### DIFF
--- a/test/trustedform-url.test.js
+++ b/test/trustedform-url.test.js
@@ -218,11 +218,11 @@ describe('TrustedForm URL', function () {
         }
       },
       masked: {
-        url: 'https://cert.trustedform.com/0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33',
+        url: 'https://cert.trustedform.com/ff5e209f324c43e2cf57ce1a080e778fecbf8285',
         expected: {
           type: 'masked',
           host: 'cert.trustedform.com',
-          path: '/0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33',
+          path: '/ff5e209f324c43e2cf57ce1a080e778fecbf8285',
           valid: true
         }
       }


### PR DESCRIPTION
I use the same test id as in this library