### PR TITLE
adding support to wildcard types in aggregate function

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -37,13 +37,24 @@ module.exports = function (event, fieldTypes) {
   for (const fieldId in fieldTypes) {
     const type = fieldTypes[fieldId];
     const aggregate = aggregations[type];
-    let value = _.get(event, fieldId);
+    let value;
+    if (type === 'wildcard') {
+      value = _.get(event, fieldId.slice(0, -2));
+    } else {
+      value = _.get(event, fieldId);
+    }
     if (aggregate != null && value != null) {
       value = typeof aggregate === 'function'
         ? aggregate(value)
         : undefined;
     }
-    if (value !== undefined) { _.set(aggregateVars, fieldId, value); }
+    if (value !== undefined) {
+      if (type === 'wildcard') {
+        _.set(aggregateVars, fieldId.slice(0, -2), value);
+      } else {
+        _.set(aggregateVars, fieldId, value);
+      }
+    }
   }
 
   return aggregateVars;

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -15,6 +15,21 @@ describe('Aggregation', function () {
   });
 });
 
+describe('Wildcard Object aggregation', function () {
+  it('Should include custom wildcard type with object data', function () {
+    const fieldTypes = { 'custom.*': 'wildcard' };
+    const vars = types.normalize({ custom: { donkey: 'kong', mario: 'bros' } });
+    const { custom } = aggregate(vars, fieldTypes);
+    assert.deepEqual(custom, { donkey: 'kong', mario: 'bros' });
+  });
+  it('Should include vars.lead.custom wildcard type with object data', function () {
+    const fieldTypes = { 'vars.lead.custom.*': 'wildcard' };
+    const vars = types.normalize({ vars: { lead: { custom: { donkey: 'kong', mario: 'bros' } } } });
+    const { vars: { lead: { custom } } } = aggregate(vars, fieldTypes);
+    assert.deepEqual(custom, { donkey: 'kong', mario: 'bros' });
+  });
+});
+
 describe('Boolean aggregation', function () {
   const fieldTypes = { boolean: 'boolean' };
 


### PR DESCRIPTION
## Description of the change
The aggregate function is used to get the data from and event and some fields as parameter, but the wildcard type fields has the suffix `.*` and lodash wasn't able to find the data inside that path, f.e: `custom.*` or `vars.custom.*`. 

So with this fix we could retrieve the wildcard appendedTypes that are required to execute advance reports using keen data.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> Link to Shortcut/Jira Ticket Goes Here

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
