### PR TITLE
Sc 50139/super admin can export leads with full dob

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,7 @@ module.exports.expandExamples = function (field) {
  * needed because event data from db doesn't have explicit type info
  * may need to add more types in the future.
  *
- * @param {*} field
+ * @param {*} field - normalized field from lead data
  * @returns {null|'dob'}
  */
 module.exports.getHideableType = function (field) {
@@ -153,7 +153,24 @@ module.exports.getHideableType = function (field) {
 
 /**
  * returns boolean based on call to getHideableType() being null or not
- * @param {*} field
+ * @param {*} field - normalized field from lead data
  * @returns {boolean}
  */
 module.exports.shouldHide = field => !!this.getHideableType(field);
+
+/**
+ * Hides sensitive information that may need to be accessed by admins
+ * when reimporting leads.
+ *
+ * @param {*} field - normalized field from lead data
+ * @returns {*}
+ */
+module.exports.hide = function (field) {
+  const type = this.getHideableType(field);
+  if (type === 'dob') {
+    const hiddenDob = `**/**/${field.year}`;
+    field.raw = hiddenDob;
+    field.normal = hiddenDob;
+  }
+  return field;
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,40 +35,77 @@ module.exports.parse = function (name, value, req) {
 };
 
 const mask = function (obj, doMask = false) {
-  if (obj == null) { return obj; }
-  if (obj instanceof Array) {
-    obj = obj.map(i => mask(i, doMask));
-  } else if (typeof obj === 'object') {
-    if (module.exports.getHideableType(obj) === 'dob') {
-      obj = module.exports.hide(obj);
-    } else if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
+  const maskObject = () => {
+    const isSpecialObject = () =>
+      obj.masked === false &&
+      (obj instanceof String ||
+        obj instanceof Boolean ||
+        obj instanceof Number ||
+        obj instanceof Date);
+    if (isSpecialObject()) {
       const str = new String(mask(obj.toString(), true));
-      for (const key in obj) {
-        const value = obj[key];
+      const keys = Object.keys(obj);
+      const promises = keys.map(async (key) => {
         if (key === 'valid') {
-          str[key] = value;
-        } else {
-          if (!key.match(digit)) { str[key] = mask(value, true); }
+          return;
         }
-      }
-      str.masked = true;
-      obj = str;
+        if (!key.match(digit)) {
+          const value = obj[key];
+          str[key] = await mask(value, true);
+        }
+      });
+      return Promise.all(promises)
+        .then(() => {
+          str.masked = true;
+          return str;
+        })
+        .catch((error) => {
+          console.error(error);
+          return str;
+        });
     } else {
-      for (const key in obj) {
+      const keys = Object.keys(obj);
+      const promises = keys.map(async (key) => {
+        if (key === 'valid') {
+          return;
+        }
         const value = obj[key];
-        if (key === 'valid') { continue; }
-        obj[key] = mask(value, (obj.masked != null) || doMask);
-      }
-      if (obj.masked != null) { obj.masked = true; }
+        obj[key] = await mask(value, obj.masked != null || doMask);
+      });
+      return Promise.all(promises)
+        .then(() => {
+          if (obj.masked != null) {
+            obj.masked = true;
+          }
+          return obj;
+        })
+        .catch((error) => {
+          console.error(error);
+          return obj;
+        });
     }
+  };
+
+  if (obj == null) {
+    return obj;
+  }
+
+  if (obj instanceof Array) {
+    return Promise.all(obj.map((i) => mask(i, doMask)));
+  } else if (typeof obj === 'object') {
+    return maskObject();
   } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {
-    if (doMask) { obj = obj.toString().replace(/./g, '*'); }
+    if (doMask) {
+      return obj.toString().replace(/./g, '*');
+    }
   } else if (_.isBoolean(obj)) {
-    if (doMask) { obj = '*'; }
+    if (doMask) {
+      return '*';
+    }
   } else if (_.isFunction(obj)) {
     // no op
   } else {
-    throw `Don't know how to mask ${obj}`; // eslint-disable-line no-throw-literal
+    throw `Don't know how to mask ${obj}`;
   }
   return obj;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,60 +35,40 @@ module.exports.parse = function (name, value, req) {
 };
 
 const mask = function (obj, doMask = false) {
-  const objType = typeof obj;
-
-  if (obj == null || objType === 'function' || obj.masked === true) {
-    return obj;
-  }
-
-  if (Array.isArray(obj)) {
-    return obj.map((i) => mask(i, doMask));
-  }
-
-  if (objType === 'object') {
-    const maskBeforeStoring = obj.masked === false;
-    const shouldConvertToString = (
-      maskBeforeStoring &&
-      (obj instanceof String ||
-        obj instanceof Boolean ||
-        obj instanceof Number ||
-        obj instanceof Date));
-    const shouldMaskObject = (maskBeforeStoring || doMask);
-
-    const maskedObj = shouldConvertToString
-      // use new String() to create a String object,
-      // which can have properties assigned to it
-      ? new String(mask(obj.toString(), true))
-      : obj;
-    // use for...in loop to loop through prototype properties
-    // obj.masked is assigned to the prototype of maskedObj
-    for (const key in obj) {
-      if (key === 'valid') {
-        maskedObj[key] = obj[key];
-      } else {
-        const shouldMask = (shouldConvertToString && !digit.test(key)) || shouldMaskObject;
-        maskedObj[key] = mask(obj[key], shouldMask);
+  if (obj == null) { return obj; }
+  if (obj instanceof Array) {
+    obj = obj.map(i => mask(i, doMask));
+  } else if (typeof obj === 'object') {
+    if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
+      const str = new String(mask(obj.toString(), true));
+      for (const key in obj) {
+        const value = obj[key];
+        if (key === 'valid') {
+          str[key] = value;
+        } else {
+          if (!key.match(digit)) { str[key] = mask(value, true); }
+        }
       }
+      str.masked = true;
+      obj = str;
+    } else {
+      for (const key in obj) {
+        const value = obj[key];
+        if (key === 'valid') { continue; }
+        obj[key] = mask(value, (obj.masked != null) || doMask);
+      }
+      if (obj.masked != null) { obj.masked = true; }
     }
-    if (maskBeforeStoring) {
-      maskedObj.masked = true;
-    }
-    return maskedObj;
+  } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {
+    if (doMask) { obj = obj.toString().replace(/./g, '*'); }
+  } else if (_.isBoolean(obj)) {
+    if (doMask) { obj = '*'; }
+  } else if (_.isFunction(obj)) {
+    // no op
+  } else {
+    throw `Don't know how to mask ${obj}`; // eslint-disable-line no-throw-literal
   }
-
-  if (!doMask) {
-    return obj;
-  }
-
-  if (/^(string|number)$/.test(objType)) {
-    return obj.toString().replace(/./g, '*');
-  }
-
-  if (objType === 'boolean') {
-    return '*';
-  }
-
-  throw new Error(`Don't know how to mask ${obj}`);
+  return obj;
 };
 
 module.exports.mask = mask;

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,7 +173,6 @@ module.exports.hide = (field) => {
       if (!_.isFunction(field[key])) str[key] = field[key];
     }
     str.raw = `**/**/${field.year}`;
-    str.masked = true;
     field = normalize(str);
   }
   return field;

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,9 +177,9 @@ module.exports.hide = (field) => {
   if (type === 'dob') {
     const maskedDob = maskDob(field);
     const str = new String(maskedDob);
-    Object.key(field).forEach(key => {
-      str[key] = field[key];
-    });
+    for (const key in field) {
+      if (!_.isFunction(field[key])) str[key] = field[key];
+    }
     str.raw = maskedDob;
     str.normal = maskedDob;
     str.masked = true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,42 +36,59 @@ module.exports.parse = function (name, value, req) {
 
 const mask = function (obj, doMask = false) {
   const maskObject = () => {
-    const isSpecialObject = () => ((obj.masked === false) &&
-        (obj instanceof String || obj instanceof Boolean ||
-          obj instanceof Number || obj instanceof Date));
+    const isSpecialObject = () =>
+      obj.masked === false &&
+      (obj instanceof String ||
+        obj instanceof Boolean ||
+        obj instanceof Number ||
+        obj instanceof Date);
     if (isSpecialObject()) {
       const str = new String(mask(obj.toString(), true));
-      for (const key in obj) {
-        if (key === 'valid') { continue; }
-        if (!key.match(digit)) {
-          str[key] = mask(obj[key], true);
+      Object.entries(obj).forEach(([key, value]) => {
+        if (key === 'valid') {
+          str[key] = value;
+        } else if (!key.match(digit)) {
+          str[key] = mask(value, true);
         }
-      }
+      });
       str.masked = true;
       return str;
     } else {
-      for (const key in obj) {
-        if (key === 'valid') { continue; }
-        obj[key] = mask(obj[key], (obj.masked != null) || doMask);
+      Object.entries(obj).forEach(([key, value]) => {
+        if (key !== 'valid') {
+          obj[key] = mask(value, obj.masked != null || doMask);
+        }
+      });
+      if (obj.masked != null) {
+        obj.masked = true;
       }
-      if (obj.masked != null) { obj.masked = true; }
       return obj;
     }
   };
-  if (obj == null) { return obj; }
-  if (obj instanceof Array) {
-    obj = obj.map(i => mask(i, doMask));
-  } else if (typeof obj === 'object') {
-    obj = maskObject();
-  } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {
-    if (doMask) { obj = obj.toString().replace(/./g, '*'); }
-  } else if (_.isBoolean(obj)) {
-    if (doMask) { obj = '*'; }
-  } else if (_.isFunction(obj)) {
-    // no op
-  } else {
-    throw `Don't know how to mask ${obj}`; // eslint-disable-line no-throw-literal
+
+  if (obj == null || _.isFunction(obj)) {
+    return obj;
   }
+
+  if (Array.isArray(obj)) {
+    Promise.all(obj.map((i) => mask(i, doMask)))
+      .then(results => {
+        return results;
+      });
+  } else if (typeof obj === 'object') {
+    return maskObject();
+  } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {
+    if (doMask) {
+      return obj.toString().replace(/./g, '*');
+    }
+  } else if (_.isBoolean(obj)) {
+    if (doMask) {
+      return '*';
+    }
+  } else {
+    throw new Error(`Don't know how to mask ${obj}`);
+  }
+
   return obj;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,8 +44,7 @@ const mask = function (obj, doMask = false) {
       for (const key in obj) {
         if (key === 'valid') { continue; }
         if (!key.match(digit)) {
-          const value = obj[key];
-          str[key] = mask(value, true);
+          str[key] = mask(obj[key], true);
         }
       }
       str.masked = true;
@@ -53,8 +52,7 @@ const mask = function (obj, doMask = false) {
     } else {
       for (const key in obj) {
         if (key === 'valid') { continue; }
-        const value = obj[key];
-        obj[key] = mask(value, (obj.masked != null) || doMask);
+        obj[key] = mask(obj[key], (obj.masked != null) || doMask);
       }
       if (obj.masked != null) { obj.masked = true; }
       return obj;

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,7 @@ module.exports.expandExamples = function (field) {
  * needed because event data from db doesn't have explicit type info
  * may need to add more types in the future.
  *
- * @param field
+ * @param {*} field
  * @returns {null|'dob'}
  */
 module.exports.getHideableType = function (field) {
@@ -150,3 +150,10 @@ module.exports.getHideableType = function (field) {
   }
   return null;
 };
+
+/**
+ * returns boolean based on call to getHideableType() being null or not
+ * @param {*} field
+ * @returns {boolean}
+ */
+module.exports.shouldHide = field => !!this.getHideableType(field);

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,16 +39,7 @@ const mask = function (obj, doMask = false) {
   if (obj instanceof Array) {
     obj = obj.map(i => mask(i, doMask));
   } else if (typeof obj === 'object') {
-    // a Date object with an age property is a dob type field
-    if (obj.masked === false && obj instanceof Date && obj.age) {
-      const str = new String(`**/**/${obj.getFullYear()}`);
-      for (const key in obj) {
-        if (!_.isFunction(obj[key])) str[key] = obj[key];
-      }
-      str.raw = `**/**/${obj.getFullYear()}`;
-      str.masked = true;
-      obj = str;
-    } else if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
+    if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
       const str = new String(mask(obj.toString(), true));
       for (const key in obj) {
         const value = obj[key];

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,3 +134,19 @@ module.exports.expandExamples = function (field) {
 
   return field;
 };
+
+/**
+ * Returns the hideable type for a field, if it has one.
+ * needed because event data from db doesn't have explicit type info
+ * may need to add more types in the future.
+ *
+ * @param field
+ * @returns {null|'dob'}
+ */
+module.exports.getHideableType = function (field) {
+  // used this function style in case we need to add more in the future
+  if (field.age && field.year) {
+    return 'dob';
+  }
+  return null;
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,6 @@ module.exports.parse = function (name, value, req) {
   }
 };
 
-const maskDob = field => `**/**/${field.year}`;
 const mask = function (obj, doMask = false) {
   const maskObject = () => {
     const isSpecialObject = () => ((obj.masked === false) &&
@@ -64,8 +63,6 @@ const mask = function (obj, doMask = false) {
     obj = obj.map(i => mask(i, doMask));
   } else if (typeof obj === 'object') {
     obj = maskObject();
-  } else if (module.exports.getHideableType(obj) === 'dob'){
-    if (doMask) { obj = maskDob(obj); }
   } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {
     if (doMask) { obj = obj.toString().replace(/./g, '*'); }
   } else if (_.isBoolean(obj)) {
@@ -175,6 +172,7 @@ module.exports.shouldHide = field => !!this.getHideableType(field);
 module.exports.hide = (field) => {
   const type = this.getHideableType(field);
   if (type === 'dob') {
+    const maskDob = field => `**/**/${field.year}`;
     const maskedDob = maskDob(field);
     const str = new String(maskedDob);
     for (const key in field) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ const mask = function (obj, doMask = false) {
   if (obj instanceof Array) {
     obj = obj.map(i => mask(i, doMask));
   } else if (typeof obj === 'object') {
-    if ((obj.masked === false) && module.exports.getHideableType(obj) === 'dob') {
+    if (module.exports.getHideableType(obj) === 'dob') {
       obj = module.exports.hide(obj);
     } else if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
       const str = new String(mask(obj.toString(), true));

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,9 @@ const mask = function (obj, doMask = false) {
   if (obj instanceof Array) {
     obj = obj.map(i => mask(i, doMask));
   } else if (typeof obj === 'object') {
-    if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
+    if ((obj.masked === false) && module.exports.getHideableType(obj) === 'dob') {
+      obj = module.exports.hide(obj);
+    } else if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
       const str = new String(mask(obj.toString(), true));
       for (const key in obj) {
         const value = obj[key];

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ module.exports.parse = function (name, value, req) {
   }
 };
 
+const maskDob = field => `**/**/${field.year}`;
 const mask = function (obj, doMask = false) {
   const maskObject = () => {
     const isSpecialObject = () => ((obj.masked === false) &&
@@ -63,6 +64,8 @@ const mask = function (obj, doMask = false) {
     obj = obj.map(i => mask(i, doMask));
   } else if (typeof obj === 'object') {
     obj = maskObject();
+  } else if (module.exports.getHideableType(obj) === 'dob'){
+    if (doMask) { obj = maskDob(obj); }
   } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {
     if (doMask) { obj = obj.toString().replace(/./g, '*'); }
   } else if (_.isBoolean(obj)) {
@@ -172,12 +175,13 @@ module.exports.shouldHide = field => !!this.getHideableType(field);
 module.exports.hide = (field) => {
   const type = this.getHideableType(field);
   if (type === 'dob') {
-    const str = new String(`**/**/${field.year}`);
-    for (const key in field) {
-      if (!_.isFunction(field[key])) str[key] = field[key];
-    }
-    str.raw = `**/**/${field.year}`;
-    str.normal = `**/**/${field.year}`;
+    const maskedDob = maskDob(field);
+    const str = new String(maskedDob);
+    Object.key(field).forEach(key => {
+      str[key] = field[key];
+    });
+    str.raw = maskedDob;
+    str.normal = maskedDob;
     str.masked = true;
     field = str;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,6 +175,6 @@ module.exports.hide = (field) => {
     str.raw = `**/**/${field.year}`;
     str.masked = true;
     field = normalize(str);
-  }z
+  }
   return field;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,62 +35,60 @@ module.exports.parse = function (name, value, req) {
 };
 
 const mask = function (obj, doMask = false) {
-  const maskObject = () => {
-    const isSpecialObject = () =>
-      obj.masked === false &&
-      (obj instanceof String ||
-        obj instanceof Boolean ||
-        obj instanceof Number ||
-        obj instanceof Date);
-    if (isSpecialObject()) {
-      const str = new String(mask(obj.toString(), true));
-      // use for...in loop to loop through prototype properties
-      for (const key in obj) {
-        if (key === 'valid') {
-          str[key] = obj[key];
-          // Using Regex.test() is faster than String.match()
-          // since we aren't using the match result
-        } else if (!digit.test(key)) {
-          str[key] = mask(obj[key], true);
-        }
-      }
-      str.masked = true;
-      return str;
-    } else {
-      // use for...in loop to loop through prototype properties
-      for (const key in obj) {
-        if (key !== 'valid') {
-          obj[key] = mask(obj[key], obj.masked != null || doMask);
-        }
-      }
-      if (obj.masked != null) {
-        obj.masked = true;
-      }
-      return obj;
-    }
-  };
+  const objType = typeof obj;
 
-  if (obj == null || _.isFunction(obj)) {
+  if (obj == null || objType === 'function' || obj.masked === true) {
     return obj;
   }
 
   if (Array.isArray(obj)) {
     return obj.map((i) => mask(i, doMask));
-  } else if (typeof obj === 'object') {
-    return maskObject();
-  } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {
-    if (doMask) {
-      return obj.toString().replace(/./g, '*');
-    }
-  } else if (_.isBoolean(obj)) {
-    if (doMask) {
-      return '*';
-    }
-  } else {
-    throw new Error(`Don't know how to mask ${obj}`);
   }
 
-  return obj;
+  if (objType === 'object') {
+    const maskBeforeStoring = obj.masked === false;
+    const shouldConvertToString = (
+      maskBeforeStoring &&
+      (obj instanceof String ||
+        obj instanceof Boolean ||
+        obj instanceof Number ||
+        obj instanceof Date));
+    const shouldMaskObject = (maskBeforeStoring || doMask);
+
+    const maskedObj = shouldConvertToString
+      // use new String() to create a String object,
+      // which can have properties assigned to it
+      ? new String(mask(obj.toString(), true))
+      : obj;
+    // use for...in loop to loop through prototype properties
+    // obj.masked is assigned to the prototype of maskedObj
+    for (const key in obj) {
+      if (key === 'valid') {
+        maskedObj[key] = obj[key];
+      } else {
+        const shouldMask = (shouldConvertToString && !digit.test(key)) || shouldMaskObject;
+        maskedObj[key] = mask(obj[key], shouldMask);
+      }
+    }
+    if (maskBeforeStoring) {
+      maskedObj.masked = true;
+    }
+    return maskedObj;
+  }
+
+  if (!doMask) {
+    return obj;
+  }
+
+  if (/^(string|number)$/.test(objType)) {
+    return obj.toString().replace(/./g, '*');
+  }
+
+  if (objType === 'boolean') {
+    return '*';
+  }
+
+  throw new Error(`Don't know how to mask ${obj}`);
 };
 
 module.exports.mask = mask;
@@ -182,7 +180,8 @@ module.exports.shouldHide = field => !!this.getHideableType(field);
 
 /**
  * Hides sensitive information that may need to be accessed by admins
- * when reimporting leads.
+ * when reimporting leads. Since we are hiding values after they are stored
+ * they will have already been normalized before saving.
  *
  * @param {*} field - normalized field from lead data
  * @returns {*}
@@ -190,9 +189,10 @@ module.exports.shouldHide = field => !!this.getHideableType(field);
 module.exports.hide = (field) => {
   const type = this.getHideableType(field);
   if (type === 'dob') {
-    const maskDob = field => `**/**/${field.year}`;
-    const maskedDob = maskDob(field);
+    const maskedDob = `**/**/${field.year}`;
+    // convert to string to protect against front end trying to use Date methods
     const str = new String(maskedDob);
+    // needed to reattach age and year properties
     for (const key in field) {
       if (!_.isFunction(field[key])) str[key] = field[key];
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,7 +165,7 @@ module.exports.shouldHide = field => !!this.getHideableType(field);
  * @param {*} field - normalized field from lead data
  * @returns {*}
  */
-module.exports.hide = function (field) {
+module.exports.hide = (field) => {
   const type = this.getHideableType(field);
   if (type === 'dob') {
     const hiddenDob = `**/**/${field.year}`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,21 +44,25 @@ const mask = function (obj, doMask = false) {
         obj instanceof Date);
     if (isSpecialObject()) {
       const str = new String(mask(obj.toString(), true));
-      Object.entries(obj).forEach(([key, value]) => {
+      // use for...in loop to loop through prototype properties
+      for (const key in obj) {
         if (key === 'valid') {
-          str[key] = value;
-        } else if (!key.match(digit)) {
-          str[key] = mask(value, true);
+          str[key] = obj[key];
+          // Using Regex.test() is faster than String.match()
+          // since we aren't using the match result
+        } else if (!digit.test(key)) {
+          str[key] = mask(obj[key], true);
         }
-      });
+      }
       str.masked = true;
       return str;
     } else {
-      Object.entries(obj).forEach(([key, value]) => {
+      // use for...in loop to loop through prototype properties
+      for (const key in obj) {
         if (key !== 'valid') {
-          obj[key] = mask(value, obj.masked != null || doMask);
+          obj[key] = mask(obj[key], obj.masked != null || doMask);
         }
-      });
+      }
       if (obj.masked != null) {
         obj.masked = true;
       }
@@ -71,13 +75,7 @@ const mask = function (obj, doMask = false) {
   }
 
   if (Array.isArray(obj)) {
-    return Promise.all(obj.map((i) => mask(i, doMask)))
-      .then(results => {
-        return results;
-      })
-      .catch(err => {
-        throw err;
-      });
+    return obj.map((i) => mask(i, doMask));
   } else if (typeof obj === 'object') {
     return maskObject();
   } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,9 +71,12 @@ const mask = function (obj, doMask = false) {
   }
 
   if (Array.isArray(obj)) {
-    Promise.all(obj.map((i) => mask(i, doMask)))
+    return Promise.all(obj.map((i) => mask(i, doMask)))
       .then(results => {
         return results;
+      })
+      .catch(err => {
+        throw err;
       });
   } else if (typeof obj === 'object') {
     return maskObject();

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,9 +172,9 @@ module.exports.hide = (field) => {
     for (const key in field) {
       if (!_.isFunction(field[key])) str[key] = field[key];
     }
-    str.raw = `**/**/${field.getFullYear()}`;
+    str.raw = `**/**/${field.year}`;
     str.masked = true;
     field = normalize(str);
-  }
+  }z
   return field;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,7 +173,9 @@ module.exports.hide = (field) => {
       if (!_.isFunction(field[key])) str[key] = field[key];
     }
     str.raw = `**/**/${field.year}`;
-    field = normalize(str);
+    str.normal = `**/**/${field.year}`;
+    str.masked = true;
+    field = str;
   }
   return field;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,9 +168,13 @@ module.exports.shouldHide = field => !!this.getHideableType(field);
 module.exports.hide = (field) => {
   const type = this.getHideableType(field);
   if (type === 'dob') {
-    const hiddenDob = `**/**/${field.year}`;
-    field.raw = hiddenDob;
-    field.normal = hiddenDob;
+    const str = new String(`**/**/${field.year}`);
+    for (const key in field) {
+      if (!_.isFunction(field[key])) str[key] = field[key];
+    }
+    str.raw = `**/**/${field.getFullYear()}`;
+    str.masked = true;
+    field = normalize(str);
   }
   return field;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -171,7 +171,6 @@ module.exports.hide = function (field) {
     const hiddenDob = `**/**/${field.year}`;
     field.raw = hiddenDob;
     field.normal = hiddenDob;
-    field.masked = true;
   }
   return field;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -171,6 +171,7 @@ module.exports.hide = function (field) {
     const hiddenDob = `**/**/${field.year}`;
     field.raw = hiddenDob;
     field.normal = hiddenDob;
+    field.masked = true;
   }
   return field;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,76 +36,43 @@ module.exports.parse = function (name, value, req) {
 
 const mask = function (obj, doMask = false) {
   const maskObject = () => {
-    const isSpecialObject = () =>
-      obj.masked === false &&
-      (obj instanceof String ||
-        obj instanceof Boolean ||
-        obj instanceof Number ||
-        obj instanceof Date);
+    const isSpecialObject = () => ((obj.masked === false) &&
+        (obj instanceof String || obj instanceof Boolean ||
+          obj instanceof Number || obj instanceof Date));
     if (isSpecialObject()) {
       const str = new String(mask(obj.toString(), true));
-      const keys = Object.keys(obj);
-      const promises = keys.map(async (key) => {
-        if (key === 'valid') {
-          return;
-        }
+      for (const key in obj) {
+        if (key === 'valid') { continue; }
         if (!key.match(digit)) {
           const value = obj[key];
-          str[key] = await mask(value, true);
+          str[key] = mask(value, true);
         }
-      });
-      return Promise.all(promises)
-        .then(() => {
-          str.masked = true;
-          return str;
-        })
-        .catch((error) => {
-          console.error(error);
-          return str;
-        });
+      }
+      str.masked = true;
+      return str;
     } else {
-      const keys = Object.keys(obj);
-      const promises = keys.map(async (key) => {
-        if (key === 'valid') {
-          return;
-        }
+      for (const key in obj) {
+        if (key === 'valid') { continue; }
         const value = obj[key];
-        obj[key] = await mask(value, obj.masked != null || doMask);
-      });
-      return Promise.all(promises)
-        .then(() => {
-          if (obj.masked != null) {
-            obj.masked = true;
-          }
-          return obj;
-        })
-        .catch((error) => {
-          console.error(error);
-          return obj;
-        });
+        obj[key] = mask(value, (obj.masked != null) || doMask);
+      }
+      if (obj.masked != null) { obj.masked = true; }
+      return obj;
     }
   };
-
-  if (obj == null) {
-    return obj;
-  }
-
+  if (obj == null) { return obj; }
   if (obj instanceof Array) {
-    return Promise.all(obj.map((i) => mask(i, doMask)));
+    obj = obj.map(i => mask(i, doMask));
   } else if (typeof obj === 'object') {
-    return maskObject();
+    obj = maskObject();
   } else if (_.isString(obj) || _.isNumber(obj) || _.isDate(obj)) {
-    if (doMask) {
-      return obj.toString().replace(/./g, '*');
-    }
+    if (doMask) { obj = obj.toString().replace(/./g, '*'); }
   } else if (_.isBoolean(obj)) {
-    if (doMask) {
-      return '*';
-    }
+    if (doMask) { obj = '*'; }
   } else if (_.isFunction(obj)) {
     // no op
   } else {
-    throw `Don't know how to mask ${obj}`;
+    throw `Don't know how to mask ${obj}`; // eslint-disable-line no-throw-literal
   }
   return obj;
 };

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -37,7 +37,6 @@ const components = [
 module.exports = {
   parse,
   components,
-  maskable: true,
   operators: [
     'is equal to',
     'is not equal to',

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -36,7 +36,7 @@ const components = [
 module.exports = {
   parse,
   components,
-  maskable: false,
+  maskable: true,
   operators: [
     'is equal to',
     'is not equal to',

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -37,6 +37,7 @@ const components = [
 module.exports = {
   parse,
   components,
+  maskable: false,
   operators: [
     'is equal to',
     'is not equal to',

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -5,7 +5,7 @@ const TENTH_OF_DAY_IN_MINUTES = 144;
 
 const parse = function (string, req) {
   const parsed = date.parse(string, req);
-  parsed.masked = false; // needed to trigger masking in requests via leadconduit-mask
+  // parsed.masked = false; // needed to trigger masking in requests via leadconduit-mask
 
   if (parsed.valid) {
     const today = moment.utc().startOf('day').add(TENTH_OF_DAY_IN_MINUTES, 'minutes');

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -5,7 +5,7 @@ const TENTH_OF_DAY_IN_MINUTES = 144;
 
 const parse = function (string, req) {
   const parsed = date.parse(string, req);
-  parsed.masked = false;
+  parsed.masked = false; // needed to trigger masking in requests via leadconduit-mask
 
   if (parsed.valid) {
     const today = moment.utc().startOf('day').add(TENTH_OF_DAY_IN_MINUTES, 'minutes');

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -5,7 +5,6 @@ const TENTH_OF_DAY_IN_MINUTES = 144;
 
 const parse = function (string, req) {
   const parsed = date.parse(string, req);
-  parsed.masked = false; // needed to trigger masking in requests via leadconduit-mask
 
   if (parsed.valid) {
     const today = moment.utc().startOf('day').add(TENTH_OF_DAY_IN_MINUTES, 'minutes');
@@ -37,7 +36,7 @@ const components = [
 module.exports = {
   parse,
   components,
-  maskable: true,
+  maskable: false,
   operators: [
     'is equal to',
     'is not equal to',

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -5,7 +5,7 @@ const TENTH_OF_DAY_IN_MINUTES = 144;
 
 const parse = function (string, req) {
   const parsed = date.parse(string, req);
-  // parsed.masked = false; // needed to trigger masking in requests via leadconduit-mask
+  parsed.masked = false; // needed to trigger masking in requests via leadconduit-mask
 
   if (parsed.valid) {
     const today = moment.utc().startOf('day').add(TENTH_OF_DAY_IN_MINUTES, 'minutes');

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -37,7 +37,7 @@ const components = [
 module.exports = {
   parse,
   components,
-  maskable: false,
+  maskable: true,
   operators: [
     'is equal to',
     'is not equal to',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,6 @@ describe('Index', function () {
     assert.equal(hidden.year, 2000);
     // check that age is still a number
     assert.isTrue(Number.isFinite(Number.parseFloat(hidden.age)));
-    assert.isTrue(hidden.masked);
     assert.isTrue(hidden.valid);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@ const { assert } = require('chai');
 const fs = require('fs');
 const path = require('path');
 const index = require('../lib');
+const dob = require('../lib/types/dob');
 
 describe('Index', function () {
   it('should list type names', function () {
@@ -34,5 +35,30 @@ describe('Index', function () {
     };
     const objClone = index.clone(obj);
     assert.deepEqual(objClone, obj);
+  });
+
+  it('returns true for dob type', function () {
+    // tests shouldHide()
+    const normalizedDob = index.normalize(dob.parse('01-01-2000'));
+    assert.isTrue(index.shouldHide(normalizedDob));
+  });
+
+  it('returns false for non-hideable type', function () {
+    // tests shouldHide()
+    const normalizedString = index.normalize('string');
+    assert.isFalse(index.shouldHide(normalizedString));
+  });
+
+  it('partially hide dob data', function () {
+    // tests getHideableType() and hide()
+    const normalizedDob = index.normalize(dob.parse('01-01-2000'));
+    const hidden = index.hide(normalizedDob);
+    assert.equal(hidden.raw, '**/**/2000');
+    assert.equal(hidden.normal, '**/**/2000');
+    assert.equal(hidden.year, 2000);
+    // check that age is still a number
+    assert.isTrue(Number.isFinite(Number.parseFloat(hidden.age)));
+    assert.isTrue(hidden.masked);
+    assert.isTrue(hidden.valid);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,27 +37,47 @@ describe('Index', function () {
     assert.deepEqual(objClone, obj);
   });
 
-  it('returns true for dob type', function () {
-    // tests shouldHide()
-    const normalizedDob = index.normalize(dob.parse('01-01-2000'));
-    assert.isTrue(index.shouldHide(normalizedDob));
-  });
+  describe('hide utility', function () {
+    describe('shouldHide', function () {
+      it('returns true for dob type', function () {
+        const normalizedDob = index.normalize(dob.parse('01-01-2000'));
+        assert.isTrue(index.shouldHide(normalizedDob));
+      });
 
-  it('returns false for non-hideable type', function () {
-    // tests shouldHide()
-    const normalizedString = index.normalize('string');
-    assert.isFalse(index.shouldHide(normalizedString));
-  });
+      it('returns false for non-hideable type', function () {
+        const normalizedString = index.normalize('string');
+        assert.isFalse(index.shouldHide(normalizedString));
+      });
+    });
 
-  it('partially hide dob data', function () {
-    // tests getHideableType() and hide()
-    const normalizedDob = index.normalize(dob.parse('01-01-2000'));
-    const hidden = index.hide(normalizedDob);
-    assert.equal(hidden.raw, '**/**/2000');
-    assert.equal(hidden.normal, '**/**/2000');
-    assert.equal(hidden.year, 2000);
-    // check that age is still a number
-    assert.isTrue(Number.isFinite(Number.parseFloat(hidden.age)));
-    assert.isTrue(hidden.valid);
+    describe('getHideableType', function () {
+      it('returns null for non-hideable type', function () {
+        // tests getHideableType()
+        const normalizedString = index.normalize('string');
+        assert.isNull(index.getHideableType(normalizedString));
+      });
+
+      it('returns dob for dob type', function () {
+        const normalizedDob = index.normalize(dob.parse('01-01-2000'));
+        assert.equal(index.getHideableType(normalizedDob), 'dob');
+      });
+    });
+
+    it('partially hide dob data', function () {
+      const normalizedDob = index.normalize(dob.parse('01-01-2000'));
+      const hidden = index.hide(normalizedDob);
+      assert.equal(hidden.raw, '**/**/2000');
+      assert.equal(hidden.normal, '**/**/2000');
+      assert.equal(hidden.year, 2000);
+      // check that age is still a number
+      assert.isTrue(Number.isFinite(Number.parseFloat(hidden.age)));
+      assert.isTrue(hidden.valid);
+    });
+
+    it('does not hide non-hideable type', function () {
+      const normalizedString = index.normalize('string');
+      const hidden = index.hide(normalizedString);
+      assert.equal(hidden, normalizedString);
+    });
   });
 });

--- a/test/mask.test.js
+++ b/test/mask.test.js
@@ -1,6 +1,5 @@
 const { assert } = require('chai');
 const { mask } = require('../lib');
-const dob = require('../lib/types/dob');
 
 describe('Mask utility', function () {
   it('should mask primitives', function () {
@@ -134,15 +133,5 @@ describe('Mask utility', function () {
     const masked = mask(str);
     assert.equal(masked.toString(), '***');
     assert.isTrue(masked.masked);
-  });
-
-  it('should partially mask dob data', function () {
-    const masked = mask(dob.parse('01-01-2000'));
-    assert.equal(masked.toString(), '**/**/2000');
-    assert.equal(masked.year, 2000);
-    // check that age is still a number
-    assert.isTrue(Number.isFinite(Number.parseFloat(masked.age)));
-    assert.isTrue(masked.masked);
-    assert.isTrue(masked.valid);
   });
 });


### PR DESCRIPTION
## Description of the change
<pre>
remove dob masking (index.js)
set dob.maskable to false (which triggers data-masking in lib/handler/middleware/source.js)
remove dob.parsed.masked (which triggers masking in requests via leadconduit-mask)
add function getHideableType(field)
   needed because event data from db doesn't have explicit type info
   returns "dob" if field has age & year attributes
   return null otherwise
add function shouldHide(field)
   returns boolean based on call to getHideableType() being null or not
add function hide(field)
  calls getHideableType(field)
  if result is not null, mask raw & normal based on type (e.g., "dob")
</pre>

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> https://app.shortcut.com/active-prospect/story/50139/super-admin-can-export-leads-with-full-dob

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [x]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut/Jira has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [x]  This branch has been deployed to staging and tested.
