### PR TITLE
Revert "Sc 50139/super admin can export leads with full dob (#157)"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,16 @@ const mask = function (obj, doMask = false) {
   if (obj instanceof Array) {
     obj = obj.map(i => mask(i, doMask));
   } else if (typeof obj === 'object') {
-    if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
+    // a Date object with an age property is a dob type field
+    if (obj.masked === false && obj instanceof Date && obj.age) {
+      const str = new String(`**/**/${obj.getFullYear()}`);
+      for (const key in obj) {
+        if (!_.isFunction(obj[key])) str[key] = obj[key];
+      }
+      str.raw = `**/**/${obj.getFullYear()}`;
+      str.masked = true;
+      obj = str;
+    } else if ((obj.masked === false) && (obj instanceof String || obj instanceof Boolean || obj instanceof Number || obj instanceof Date)) {
       const str = new String(mask(obj.toString(), true));
       for (const key in obj) {
         const value = obj[key];
@@ -132,54 +141,5 @@ module.exports.expandExamples = function (field) {
     })
   );
 
-  return field;
-};
-
-/**
- * Returns the hideable type for a field, if it has one.
- * needed because event data from db doesn't have explicit type info
- * may need to add more types in the future.
- *
- * @param {*} field - normalized field from lead data
- * @returns {null|'dob'}
- */
-module.exports.getHideableType = function (field) {
-  // used this function style in case we need to add more in the future
-  if (field.age && field.year) {
-    return 'dob';
-  }
-  return null;
-};
-
-/**
- * returns boolean based on call to getHideableType() being null or not
- * @param {*} field - normalized field from lead data
- * @returns {boolean}
- */
-module.exports.shouldHide = field => !!this.getHideableType(field);
-
-/**
- * Hides sensitive information that may need to be accessed by admins
- * when reimporting leads. Since we are hiding values after they are stored
- * they will have already been normalized before saving.
- *
- * @param {*} field - normalized field from lead data
- * @returns {*}
- */
-module.exports.hide = (field) => {
-  const type = this.getHideableType(field);
-  if (type === 'dob') {
-    const maskedDob = `**/**/${field.year}`;
-    // convert to string to protect against front end trying to use Date methods
-    const str = new String(maskedDob);
-    // needed to reattach age and year properties
-    for (const key in field) {
-      if (!_.isFunction(field[key])) str[key] = field[key];
-    }
-    str.raw = maskedDob;
-    str.normal = maskedDob;
-    str.masked = true;
-    field = str;
-  }
   return field;
 };

--- a/lib/types/dob.js
+++ b/lib/types/dob.js
@@ -5,6 +5,7 @@ const TENTH_OF_DAY_IN_MINUTES = 144;
 
 const parse = function (string, req) {
   const parsed = date.parse(string, req);
+  parsed.masked = false;
 
   if (parsed.valid) {
     const today = moment.utc().startOf('day').add(TENTH_OF_DAY_IN_MINUTES, 'minutes');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,6 @@ const { assert } = require('chai');
 const fs = require('fs');
 const path = require('path');
 const index = require('../lib');
-const dob = require('../lib/types/dob');
 
 describe('Index', function () {
   it('should list type names', function () {
@@ -35,49 +34,5 @@ describe('Index', function () {
     };
     const objClone = index.clone(obj);
     assert.deepEqual(objClone, obj);
-  });
-
-  describe('hide utility', function () {
-    describe('shouldHide', function () {
-      it('returns true for dob type', function () {
-        const normalizedDob = index.normalize(dob.parse('01-01-2000'));
-        assert.isTrue(index.shouldHide(normalizedDob));
-      });
-
-      it('returns false for non-hideable type', function () {
-        const normalizedString = index.normalize('string');
-        assert.isFalse(index.shouldHide(normalizedString));
-      });
-    });
-
-    describe('getHideableType', function () {
-      it('returns null for non-hideable type', function () {
-        // tests getHideableType()
-        const normalizedString = index.normalize('string');
-        assert.isNull(index.getHideableType(normalizedString));
-      });
-
-      it('returns dob for dob type', function () {
-        const normalizedDob = index.normalize(dob.parse('01-01-2000'));
-        assert.equal(index.getHideableType(normalizedDob), 'dob');
-      });
-    });
-
-    it('partially hide dob data', function () {
-      const normalizedDob = index.normalize(dob.parse('01-01-2000'));
-      const hidden = index.hide(normalizedDob);
-      assert.equal(hidden.raw, '**/**/2000');
-      assert.equal(hidden.normal, '**/**/2000');
-      assert.equal(hidden.year, 2000);
-      // check that age is still a number
-      assert.isTrue(Number.isFinite(Number.parseFloat(hidden.age)));
-      assert.isTrue(hidden.valid);
-    });
-
-    it('does not hide non-hideable type', function () {
-      const normalizedString = index.normalize('string');
-      const hidden = index.hide(normalizedString);
-      assert.equal(hidden, normalizedString);
-    });
   });
 });

--- a/test/mask.test.js
+++ b/test/mask.test.js
@@ -1,5 +1,6 @@
 const { assert } = require('chai');
 const { mask } = require('../lib');
+const dob = require('../lib/types/dob');
 
 describe('Mask utility', function () {
   it('should mask primitives', function () {
@@ -133,5 +134,15 @@ describe('Mask utility', function () {
     const masked = mask(str);
     assert.equal(masked.toString(), '***');
     assert.isTrue(masked.masked);
+  });
+
+  it('should partially mask dob data', function () {
+    const masked = mask(dob.parse('01-01-2000'));
+    assert.equal(masked.toString(), '**/**/2000');
+    assert.equal(masked.year, 2000);
+    // check that age is still a number
+    assert.isTrue(Number.isFinite(Number.parseFloat(masked.age)));
+    assert.isTrue(masked.masked);
+    assert.isTrue(masked.valid);
   });
 });


### PR DESCRIPTION
After conversations with Scott and Alex; we have decided to keep the dob type as a masked type, and make it optional to use a new standard field called dob secured or something to that effect.

## Description of the change

> This reverts commit c121836ce2d77d05f4ba25d150c5940980a2f082.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> https://app.shortcut.com/active-prospect/story/50139/super-admin-can-export-leads-with-full-dob

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut/Jira has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [x]  This branch has been deployed to staging and tested.
