### PR TITLE
update to use latest chrono-node/handle excessive fractional seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@activeprospect/freemail": "^1.5.2",
     "@activeprospect/indexer": "^1.3.2",
     "@activeprospect/trustedform-cert-id": "^1.1.1",
-    "chrono-node": "git+https://github.com/alexkwolfe/chrono.git#milliseconds",
+    "chrono-node": "^2.6.3",
     "domain-name-parser": "0.0.4",
     "email-addresses": "^1.1.1",
     "faker": "^3.0.1",

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -71,6 +71,15 @@ describe('Time', function () {
     assert.isTrue(date.valid);
   });
 
+  it('should handle zero fractional second digits', function () {
+    const date = time.parse('2014-06-14T18:27:33Z');
+    assert.instanceOf(date, Date);
+    assert.equal(date.toString(), '2014-06-14T18:27:33.000Z');
+    assert.equal(date.valueOf(), '2014-06-14T18:27:33.000Z');
+    assert.equal(date.raw, '2014-06-14T18:27:33Z');
+    assert.isTrue(date.valid);
+  });
+
   it('should handle three fractional second digits (JavaScript default)', function () {
     const date = time.parse('2014-06-14T18:27:33.123Z');
     assert.instanceOf(date, Date);

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -71,6 +71,24 @@ describe('Time', function () {
     assert.isTrue(date.valid);
   });
 
+  it('should handle three fractional second digits (JavaScript default)', function () {
+    const date = time.parse('2014-06-14T18:27:33.123Z');
+    assert.instanceOf(date, Date);
+    assert.equal(date.toString(), '2014-06-14T18:27:33.123Z');
+    assert.equal(date.valueOf(), '2014-06-14T18:27:33.123Z');
+    assert.equal(date.raw, '2014-06-14T18:27:33.123Z');
+    assert.isTrue(date.valid);
+  });
+
+  it('should handle more than four fractional second digits', function () {
+    const date = time.parse('2014-06-14T18:27:33.12345Z');
+    assert.instanceOf(date, Date);
+    assert.equal(date.toString(), '2014-06-14T18:27:33.000Z');
+    assert.equal(date.valueOf(), '2014-06-14T18:27:33.000Z');
+    assert.equal(date.raw, '2014-06-14T18:27:33.12345Z');
+    assert.isTrue(date.valid);
+  });
+
   it('should handle parsing a JavaScript date', function () {
     const now = new Date(2015, 10, 6, 11, 47, 42); // 0-based month index :-/
     const parsed = time.parse(now);


### PR DESCRIPTION
## Description of the change

Fixes the `time` type's handling of timestamps with more than 4 decimal places of fractional seconds.

This is accomplished by updating to use the latest public version of `chrono-node`, which is used for the fundamental time parsing. 

@alexkwolfe - Let me know if you have concerns about this change - it replaces your previously branched version at [`git+https://github.com/alexkwolfe/chrono.git#milliseconds`](https://github.com/alexkwolfe/chrono/commits/milliseconds). It looks like your change was to add support for parsing milliseconds (what I'm calling "fractional seconds" here). Now the mainline public version of `chrono-node` does that itself, plus whatever other fixes (including vulnerabilities) since your fork. All the time tests still pass, of course. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [x] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/58714/lc-time-type-fails-on-too-many-decimal-places-of-fractional-seconds

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
