### PR TITLE
Sc 60407/add ipv6 support to the ip address data type

### DIFF
--- a/lib/types/ip.js
+++ b/lib/types/ip.js
@@ -91,12 +91,12 @@ const parse = function (str) {
     parsed = new String(uri.hostname);
     parsed.valid = true;
     if (startsWithIpv4(uri.hostname)) {
-      parsed.isIpv4 = true;
+      parsed.is_ipv4 = true;
       // IP v4 can be converted to IP v6; however, the reverse is not true
-      parsed.mapToIpv6 = mapIpv4ToIpv6(uri.hostname);
+      parsed.ipv6_format = mapIpv4ToIpv6(uri.hostname);
     } else {
-      parsed.isIpv4 = false;
-      parsed.mapToIpv6 = uri.hostname;
+      parsed.is_ipv4 = false;
+      parsed.ipv6_format = uri.hostname;
     }
   } catch (e) {
     parsed = new String(str);
@@ -112,8 +112,8 @@ module.exports = {
 
   components: [
     { name: 'raw', type: 'string', description: 'Unmodified value' },
-    { name: 'isIpv4', type: 'boolean', description: 'Whether the IP address is IP v4 or not' },
-    { name: 'mapToIpv6', type: 'string', description: 'The IP converted to IP v6' }
+    { name: 'is_ipv4', type: 'boolean', description: 'Whether the IP address is IP v4 or not' },
+    { name: 'ipv6_format', type: 'string', description: 'The IP converted to IP v6' }
   ],
   maskable: false,
   operators: [

--- a/lib/types/ip.js
+++ b/lib/types/ip.js
@@ -1,0 +1,138 @@
+const { URL } = require('url');
+const normalize = require('../normalize');
+const ensureString = require('../ensureString');
+
+/**
+ * Parses ip if in the following formats:
+ * ipv4: 128.71.239.188
+ * ipv6: [1268:753d:682d:3dab:3596:cc01:6891:e1a6]
+ * @param {string} ipStr
+ * @returns {module:url.URL}
+ */
+function parseIpFormat (ipStr) {
+  return new URL(`https://${ipStr}`);
+}
+
+/**
+ * Parses ipv6 if in the following formats:
+ * ipv6: 1268:753d:682d:3dab:3596:cc01:6891:e1a6
+ * ipv6 with path: 1268:753d:682d:3dab:3596:cc01:6891:e1a6/hello
+ * @param {string} ipStr
+ * @returns {module:url.URL} - [1268:753d:682d:3dab:3596:cc01:6891:e1a6]/hello
+ */
+function parseIpv6WithoutBrackets (ipStr) {
+  const ipv6LikeRegex = /^((::ffff|ffff:):(\d{1,3}\.){3}\d{1,3}|(([0-9a-f]{0,4}|:)(:[0-9a-f]{0,4}){0,7}))/i;
+  const str = ipStr.replace(ipv6LikeRegex, '[$1]');
+  return parseIpFormat(str);
+}
+
+/**
+ * Map ipv4 to ipv6 for ipv6 systems to talk to ipv4 systems:
+ * @param {string} ipStr - 192.168.100.228
+ * @returns {string} - [::ffff:c0a8:64e4]
+ */
+function mapIpv4ToIpv6 (ipStr) {
+  const parsed = new URL(`https://[ffff::${ipStr}]`);
+  return parsed.hostname;
+}
+
+/**
+ * @description Checks string for "://" to determine if it has a protocol (e.g. http, https, ftp, etc.)
+ * @param {string} str
+ * @returns {boolean}
+ */
+function hasProtocol (str) {
+  return /:\/\//.test(str);
+}
+
+/**
+ * @description Ipv4 can be mapped to Ipv6; however, when an ipv4 is included in the ipv6
+ * it occurs at the end of the ipv6 address. This function checks if the string starts with
+ * an ipv4 address while allowing for the inclusion of a port number or path included with the string.
+ * @param {string} str
+ * @returns {boolean}
+ */
+function startsWithIpv4 (str) {
+  return /^(\d{1,3}\.){3}\d{1,3}\b/.test(str);
+}
+
+/**
+ * @description Checks if string has brackets like ipv6 (e.g. [::ffff:c0a8:64e4])
+ * @param {string} str
+ * @returns {boolean}
+ */
+function hasBrackets (str) {
+  return /^\[.*]/.test(str);
+}
+
+function parseIp (ipStr) {
+  if (hasProtocol(ipStr)) {
+    // strip protocol recall function
+    // this will prevent https://google.com from being parsed as an ip
+    // and avoid duplicating logic
+    return parseIp(ipStr.replace(/^.*:\/\//, ''));
+  }
+
+  if (startsWithIpv4(ipStr) || hasBrackets(ipStr)) {
+    return parseIpFormat(ipStr);
+  }
+
+  return parseIpv6WithoutBrackets(ipStr);
+}
+
+const parse = function (str) {
+  if (str == null) { return str; }
+
+  const raw = ensureString(str);
+
+  let parsed;
+  try {
+    const uri = parseIp(raw.replace(/\s/g, ''));
+    parsed = new String(uri.hostname);
+    parsed.valid = true;
+    if (startsWithIpv4(uri.hostname)) {
+      parsed.isIpv4 = true;
+      // IP v4 can be converted to IP v6; however, the reverse is not true
+      parsed.mapToIpv6 = mapIpv4ToIpv6(uri.hostname);
+    } else {
+      parsed.isIpv4 = false;
+      parsed.mapToIpv6 = uri.hostname;
+    }
+  } catch (e) {
+    parsed = new String(str);
+    parsed.valid = false;
+  }
+
+  parsed.raw = raw;
+  return parsed;
+};
+
+module.exports = {
+  parse,
+
+  components: [
+    { name: 'raw', type: 'string', description: 'Unmodified value' },
+    { name: 'isIpv4', type: 'boolean', description: 'Whether the IP address is IP v4 or not' },
+    { name: 'mapToIpv6', type: 'string', description: 'The IP converted to IP v6' }
+  ],
+  maskable: false,
+  operators: [
+    'is equal to',
+    'is not equal to',
+    'is blank',
+    'is not blank',
+    'format is valid',
+    'format is invalid',
+    'includes',
+    'does not include',
+    'is included in',
+    'is not included in'
+  ],
+  examples: [
+    '198.51.90.161',
+    'https://198.51.90.162',
+    '0d49:6f05:e485:29bb:3122:f151:aa71:4a3b',
+    '[ffff::198.51.90.163]',
+    'https://[56c6:75e8:cddf:199b:f696:4192:baae:eb2e]'
+  ].map(parse).map(normalize)
+};

--- a/lib/types/url.js
+++ b/lib/types/url.js
@@ -1,4 +1,4 @@
-const url = require('url');
+const { URL } = require('url');
 const normalize = require('../normalize');
 const ensureString = require('../ensureString');
 

--- a/test/ip.test.js
+++ b/test/ip.test.js
@@ -1,0 +1,200 @@
+const { assert } = require('chai');
+const ip = require('../lib/types/ip');
+
+describe('IP', function () {
+  it('should not parse null', function () {
+    assert.isNull(ip.parse(null));
+  });
+
+  it('should not parse undefined', function () {
+    assert.isUndefined(ip.parse());
+  });
+
+  it('should parse a parsed ipv4', function () {
+    const randomIpv4 = '198.51.90.161';
+    const parsed = ip.parse(ip.parse(randomIpv4));
+    assert.equal(parsed.toString(), randomIpv4);
+    assert.equal(parsed.raw, randomIpv4);
+    assert.equal(parsed.mapToIpv6, '[ffff::c633:5aa1]');
+    assert.isTrue(parsed.valid);
+    assert.isTrue(parsed.isIpv4);
+  });
+
+  it('should parse a parsed ipv6', function () {
+    const randomIpv6 = '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]';
+    const parsed = ip.parse(ip.parse(randomIpv6));
+    assert.equal(parsed.toString(), randomIpv6);
+    assert.equal(parsed.raw, randomIpv6);
+    assert.equal(parsed.mapToIpv6, randomIpv6);
+    assert.isTrue(parsed.valid);
+    assert.isFalse(parsed.isIpv4);
+  });
+
+  it('should have examples', function () {
+    assert(ip.examples.length > 0);
+  });
+
+  describe('valid ipv4', function () {
+    const strings = [
+      '198.51.90.161',
+      '198.51.90.161/32', // cidr notation
+      'http://198.51.90.161:32', // url with port
+      'http://198.51.90.161',
+      '    198. 51. 90. 161     ', // whitespace
+      '    http://198.51.90.161     '
+    ];
+
+    for (const string of strings) {
+      describe(`'${string}'`, function () {
+        beforeEach(function () {
+          this.parsed = ip.parse(string);
+        });
+
+        it('should keep raw value', function () {
+          assert.equal(this.parsed.raw, string);
+        });
+
+        it('should have mapToIpv6', function () {
+          assert.equal(this.parsed.mapToIpv6, '[ffff::c633:5aa1]');
+        });
+
+        it('should be normalized', function () {
+          assert.equal(this.parsed.valueOf(), '198.51.90.161');
+        });
+
+        it('should be marked valid', function () {
+          assert.isTrue(this.parsed.valid);
+        });
+
+        it('should be marked ipv4', function () {
+          assert.isTrue(this.parsed.isIpv4);
+        });
+      });
+    }
+  });
+
+  describe('valid ipv6', function () {
+    const strings = [
+      '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]',
+      '8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9',
+      '    [8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]     ', // whitespace
+      '    http://[8faa:    230d:52ab:98f3:a2ea:    7735:a7b8:72e9]     ',
+      'http://[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]:32', // <- url with port
+      '8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9/64' // <- CIDR notation
+    ];
+
+    for (const string of strings) {
+      describe(`'${string}'`, function () {
+        beforeEach(function () {
+          this.parsed = ip.parse(string);
+        });
+
+        it('should keep raw value', function () {
+          assert.equal(this.parsed.raw, string);
+        });
+
+        it('should have mapToIpv6', function () {
+          assert.equal(this.parsed.mapToIpv6, '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]');
+        });
+
+        it('should be normalized', function () {
+          assert.equal(this.parsed.valueOf(), '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]');
+        });
+
+        it('should be marked valid', function () {
+          assert.isTrue(this.parsed.valid);
+        });
+
+        it('should be marked ipv4', function () {
+          assert.isFalse(this.parsed.isIpv4);
+        });
+      });
+    }
+  });
+
+  describe('irregular ipv6', function () {
+    it('should parse ipv6 with leading zeros', function () {
+      const string = '[0000:0000:0000:0000:0000:0000:0000:0001]';
+      const parsed = ip.parse(string);
+      assert.equal(parsed.valueOf(), '[::1]');
+      assert.isTrue(parsed.valid);
+    });
+
+    it('should parse ipv6 with ipv4 tail', function () {
+      const string = '[ffff::186.25.192.233]';
+      const parsed = ip.parse(string);
+      assert.equal(parsed.valueOf(), '[ffff::ba19:c0e9]');
+      assert.isTrue(parsed.valid);
+    });
+
+    it('should parse ipv6 with ipv4 tail (alternate form)', function () {
+      const string = '[::ffff:186.25.192.233]';
+      const parsed = ip.parse(string);
+      assert.equal(parsed.valueOf(), '[::ffff:ba19:c0e9]');
+      assert.isTrue(parsed.valid);
+    });
+  });
+
+  describe('values that get coerced to valid', function () {
+    const strings = [
+      'http://8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9', // <- leads with protocol without brackets around ipv6
+      '8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9:32', // <- ends with port without brackets
+      '198.51.90.161/extra_path',
+      '198.51.90.161/33', // <- max cidr is 32 for ipv4
+      '8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9/129', // <- max cidr is 128 for ipv6
+      'http://8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9',
+      'http://8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9/extra_path'
+    ];
+
+    for (const string of strings) {
+      describe(`'${string}'`, function () {
+        beforeEach(function () {
+          this.parsed = ip.parse(string);
+        });
+
+        it('should keep raw value', function () {
+          assert.equal(this.parsed.raw, string);
+        });
+
+        it('should be valid', function () {
+          assert.isTrue(this.parsed.valid);
+        });
+      });
+    }
+  });
+
+  describe('invalid values', function () {
+    const strings = [
+      '',
+      ' ',
+      'https://google.com',
+      'https://',
+      'donkey://google.com',
+      { foo: 42 },
+      'fe80:2030:31:24', // <- colons need to separate 2 byte segements for a total of 16-bytes
+      '256.4.5.6', // <- ipv4 with invalid octet (256)
+      '56FE::2159:5BBC::6594', // <- two sets of double colons
+      '::GG' // <- invalid hex character (G)
+    ];
+
+    for (const string of strings) {
+      describe(`'${string}'`, function () {
+        beforeEach(function () {
+          this.parsed = ip.parse(string);
+        });
+
+        it('should keep raw value', function () {
+          assert.equal(this.parsed.raw, string);
+        });
+
+        it('should not be valid', function () {
+          assert.isFalse(this.parsed.valid);
+        });
+
+        it('should be normalized', function () {
+          assert.equal(this.parsed.valueOf(), string);
+        });
+      });
+    }
+  });
+});

--- a/test/ip.test.js
+++ b/test/ip.test.js
@@ -15,9 +15,9 @@ describe('IP', function () {
     const parsed = ip.parse(ip.parse(randomIpv4));
     assert.equal(parsed.toString(), randomIpv4);
     assert.equal(parsed.raw, randomIpv4);
-    assert.equal(parsed.mapToIpv6, '[ffff::c633:5aa1]');
+    assert.equal(parsed.ipv6_format, '[ffff::c633:5aa1]');
     assert.isTrue(parsed.valid);
-    assert.isTrue(parsed.isIpv4);
+    assert.isTrue(parsed.is_ipv4);
   });
 
   it('should parse a parsed ipv6', function () {
@@ -25,9 +25,9 @@ describe('IP', function () {
     const parsed = ip.parse(ip.parse(randomIpv6));
     assert.equal(parsed.toString(), randomIpv6);
     assert.equal(parsed.raw, randomIpv6);
-    assert.equal(parsed.mapToIpv6, randomIpv6);
+    assert.equal(parsed.ipv6_format, randomIpv6);
     assert.isTrue(parsed.valid);
-    assert.isFalse(parsed.isIpv4);
+    assert.isFalse(parsed.is_ipv4);
   });
 
   it('should have examples', function () {
@@ -54,8 +54,8 @@ describe('IP', function () {
           assert.equal(this.parsed.raw, string);
         });
 
-        it('should have mapToIpv6', function () {
-          assert.equal(this.parsed.mapToIpv6, '[ffff::c633:5aa1]');
+        it('should have ipv6_format', function () {
+          assert.equal(this.parsed.ipv6_format, '[ffff::c633:5aa1]');
         });
 
         it('should be normalized', function () {
@@ -67,7 +67,7 @@ describe('IP', function () {
         });
 
         it('should be marked ipv4', function () {
-          assert.isTrue(this.parsed.isIpv4);
+          assert.isTrue(this.parsed.is_ipv4);
         });
       });
     }
@@ -93,8 +93,8 @@ describe('IP', function () {
           assert.equal(this.parsed.raw, string);
         });
 
-        it('should have mapToIpv6', function () {
-          assert.equal(this.parsed.mapToIpv6, '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]');
+        it('should have ipv6_format', function () {
+          assert.equal(this.parsed.ipv6_format, '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]');
         });
 
         it('should be normalized', function () {
@@ -106,7 +106,7 @@ describe('IP', function () {
         });
 
         it('should be marked ipv4', function () {
-          assert.isFalse(this.parsed.isIpv4);
+          assert.isFalse(this.parsed.is_ipv4);
         });
       });
     }

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -60,7 +60,7 @@ describe('URL', function () {
           assert.equal(this.parsed.query, 'q=hi');
         });
 
-        it('should have query', function () {
+        it('should have hash', function () {
           assert.equal(this.parsed.hash, '#results');
         });
 


### PR DESCRIPTION
## Description of the change

> Create IP type, Validate IP addresses using Node's built-in URL API, fix minor issues with url type for clarity.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [x] Technical Debt
- [ ] Documentation

## Related tickets

> https://app.shortcut.com/active-prospect/story/60407/add-ipv6-support-to-the-ip-address-data-type

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut/Jira has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
