### PR TITLE
sc-62374/remove-bracket-on-ipv6-ip-addresses

### DIFF
--- a/lib/types/ip.js
+++ b/lib/types/ip.js
@@ -33,7 +33,7 @@ function parseIpv6WithoutBrackets (ipStr) {
  */
 function mapIpv4ToIpv6 (ipStr) {
   const parsed = new URL(`https://[ffff::${ipStr}]`);
-  return parsed.hostname;
+  return stripBrackets(parsed.hostname);
 }
 
 /**
@@ -43,6 +43,15 @@ function mapIpv4ToIpv6 (ipStr) {
  */
 function hasProtocol (str) {
   return /:\/\//.test(str);
+}
+
+/**
+ * @description Removes brackets from ipv6 (e.g. [::ffff:c0a8:64e4] -> ::ffff:c0a8:64e4)
+ * @param {string} ip
+ * @returns {string}
+ */
+function stripBrackets (ip) {
+  return ip.replace(/[\][]/g, '');
 }
 
 /**
@@ -88,7 +97,8 @@ const parse = function (str) {
   let parsed;
   try {
     const uri = parseIp(raw.replace(/\s/g, ''));
-    parsed = new String(uri.hostname);
+    const ip = stripBrackets(uri.hostname);
+    parsed = new String(ip);
     parsed.valid = true;
     if (startsWithIpv4(uri.hostname)) {
       parsed.is_ipv4 = true;
@@ -96,7 +106,7 @@ const parse = function (str) {
       parsed.ipv6_format = mapIpv4ToIpv6(uri.hostname);
     } else {
       parsed.is_ipv4 = false;
-      parsed.ipv6_format = uri.hostname;
+      parsed.ipv6_format = ip;
     }
   } catch (e) {
     parsed = new String(str);

--- a/test/ip.test.js
+++ b/test/ip.test.js
@@ -15,13 +15,13 @@ describe('IP', function () {
     const parsed = ip.parse(ip.parse(randomIpv4));
     assert.equal(parsed.toString(), randomIpv4);
     assert.equal(parsed.raw, randomIpv4);
-    assert.equal(parsed.ipv6_format, '[ffff::c633:5aa1]');
+    assert.equal(parsed.ipv6_format, 'ffff::c633:5aa1');
     assert.isTrue(parsed.valid);
     assert.isTrue(parsed.is_ipv4);
   });
 
   it('should parse a parsed ipv6', function () {
-    const randomIpv6 = '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]';
+    const randomIpv6 = '8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9';
     const parsed = ip.parse(ip.parse(randomIpv6));
     assert.equal(parsed.toString(), randomIpv6);
     assert.equal(parsed.raw, randomIpv6);
@@ -55,7 +55,7 @@ describe('IP', function () {
         });
 
         it('should have ipv6_format', function () {
-          assert.equal(this.parsed.ipv6_format, '[ffff::c633:5aa1]');
+          assert.equal(this.parsed.ipv6_format, 'ffff::c633:5aa1');
         });
 
         it('should be normalized', function () {
@@ -94,11 +94,11 @@ describe('IP', function () {
         });
 
         it('should have ipv6_format', function () {
-          assert.equal(this.parsed.ipv6_format, '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]');
+          assert.equal(this.parsed.ipv6_format, '8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9');
         });
 
         it('should be normalized', function () {
-          assert.equal(this.parsed.valueOf(), '[8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9]');
+          assert.equal(this.parsed.valueOf(), '8faa:230d:52ab:98f3:a2ea:7735:a7b8:72e9');
         });
 
         it('should be marked valid', function () {
@@ -116,21 +116,21 @@ describe('IP', function () {
     it('should parse ipv6 with leading zeros', function () {
       const string = '[0000:0000:0000:0000:0000:0000:0000:0001]';
       const parsed = ip.parse(string);
-      assert.equal(parsed.valueOf(), '[::1]');
+      assert.equal(parsed.valueOf(), '::1');
       assert.isTrue(parsed.valid);
     });
 
     it('should parse ipv6 with ipv4 tail', function () {
       const string = '[ffff::186.25.192.233]';
       const parsed = ip.parse(string);
-      assert.equal(parsed.valueOf(), '[ffff::ba19:c0e9]');
+      assert.equal(parsed.valueOf(), 'ffff::ba19:c0e9');
       assert.isTrue(parsed.valid);
     });
 
     it('should parse ipv6 with ipv4 tail (alternate form)', function () {
       const string = '[::ffff:186.25.192.233]';
       const parsed = ip.parse(string);
-      assert.equal(parsed.valueOf(), '[::ffff:ba19:c0e9]');
+      assert.equal(parsed.valueOf(), '::ffff:ba19:c0e9');
       assert.isTrue(parsed.valid);
     });
   });


### PR DESCRIPTION
## Description of the change

> add function to strip off brackets included by URL class on hostname for IP v6 addresses

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> https://app.shortcut.com/active-prospect/story/62374/remove-bracket-on-ipv6-ip-addresses-leadconduit-types

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
