### PR TITLE
sc-74325/profanity-obscenity-package-implement-as

### DIFF
--- a/lib/types/city.js
+++ b/lib/types/city.js
@@ -23,6 +23,8 @@ module.exports = {
     'is not equal to',
     'is blank',
     'is not blank',
+    'is obscene',
+    'is not obscene',
     'format is valid',
     'format is invalid',
     'includes',

--- a/lib/types/email.js
+++ b/lib/types/email.js
@@ -57,6 +57,8 @@ module.exports = {
     'is not equal to',
     'is blank',
     'is not blank',
+    'is obscene',
+    'is not obscene',
     'format is valid',
     'format is invalid',
     'includes',

--- a/lib/types/first_name.js
+++ b/lib/types/first_name.js
@@ -23,6 +23,8 @@ module.exports = {
     'is not equal to',
     'is blank',
     'is not blank',
+    'is obscene',
+    'is not obscene',
     'format is valid',
     'format is invalid',
     'matches pattern',

--- a/lib/types/last_name.js
+++ b/lib/types/last_name.js
@@ -23,6 +23,8 @@ module.exports = {
     'is not equal to',
     'is blank',
     'is not blank',
+    'is obscene',
+    'is not obscene',
     'format is valid',
     'format is invalid',
     'matches pattern',

--- a/lib/types/state.js
+++ b/lib/types/state.js
@@ -127,6 +127,8 @@ module.exports = {
     'is not equal to',
     'is blank',
     'is not blank',
+    'is obscene',
+    'is not obscene',
     'includes',
     'does not include',
     'is included in',

--- a/lib/types/street.js
+++ b/lib/types/street.js
@@ -36,6 +36,8 @@ module.exports = {
     'is not equal to',
     'is blank',
     'is not blank',
+    'is obscene',
+    'is not obscene',
     'format is valid',
     'format is invalid',
     'includes',

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -10,6 +10,8 @@ module.exports = {
     'is not equal to',
     'is blank',
     'is not blank',
+    'is obscene',
+    'is not obscene',
     'includes',
     'does not include',
     'is included in',

--- a/lib/types/url.js
+++ b/lib/types/url.js
@@ -59,6 +59,8 @@ module.exports = {
     'is not equal to',
     'is blank',
     'is not blank',
+    'is obscene',
+    'is not obscene',
     'format is valid',
     'format is invalid',
     'includes',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "named-regexp": "^0.1.1"
   },
   "devDependencies": {
-    "@activeprospect/leadconduit-rules": "^2.10.2",
+    "@activeprospect/leadconduit-rules": "^2.11.0",
     "chai": "^4.2.0",
     "eslint": "^8.39.0",
     "eslint-config-semistandard": "^17.0.0",

--- a/test/city.test.js
+++ b/test/city.test.js
@@ -29,6 +29,8 @@ describe('City', function () {
       'is not equal to',
       'is blank',
       'is not blank',
+      'is obscene',
+      'is not obscene',
       'format is valid',
       'format is invalid',
       'includes',

--- a/test/first-name.test.js
+++ b/test/first-name.test.js
@@ -29,6 +29,8 @@ describe('First Name', function () {
       'is not equal to',
       'is blank',
       'is not blank',
+      'is obscene',
+      'is not obscene',
       'format is valid',
       'format is invalid',
       'matches pattern',

--- a/test/last-name.test.js
+++ b/test/last-name.test.js
@@ -29,6 +29,8 @@ describe('Last Name', function () {
       'is not equal to',
       'is blank',
       'is not blank',
+      'is obscene',
+      'is not obscene',
       'format is valid',
       'format is invalid',
       'matches pattern',


### PR DESCRIPTION
## Description of the change

> add `is obscene` and `is not obscene` operators

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> https://app.shortcut.com/active-prospect/story/74325/profanity-obscenity-package-implement-as-a-unary-rule-for-leads-filtering

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [x]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut/Jira has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [x]  This branch has been deployed to staging and tested.
