### PR TITLE
improve handling of non-US phone numbers

### DIFF
--- a/lib/types/phone.js
+++ b/lib/types/phone.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const phoneUtil = require('google-libphonenumber').PhoneNumberUtil.getInstance();
 const normalize = require('../normalize');
 const ensureString = require('../ensureString');
+const countryCodes = require('country-calling-code').codes;
 
 const supportedRegionCodes = [
   'US', // united states
@@ -96,6 +97,10 @@ const resolve = function (string, logger) {
   }
 
   if (number) {
+    const countryCallingCode = number.getCountryCode();
+    if (countryCallingCode !== 1) {
+      regionCode = _.find(countryCodes, function (country) { return country.countryCodes.includes(countryCallingCode.toString()); }).isoCode2;
+    }
     return [number, regionCode, mask];
   } else {
     return [null, null, null];

--- a/lib/types/phone.js
+++ b/lib/types/phone.js
@@ -2,13 +2,6 @@ const _ = require('lodash');
 const phoneUtil = require('google-libphonenumber').PhoneNumberUtil.getInstance();
 const normalize = require('../normalize');
 const ensureString = require('../ensureString');
-const countryCodes = require('country-calling-code').codes;
-
-const supportedRegionCodes = [
-  'US', // united states
-  'CA', // canada
-  'GB' // uk
-];
 
 const tollFreeAreaCodes = {
   800: true,
@@ -27,12 +20,12 @@ const parse = function (string, req) {
   string = results[1];
 
   const logger = req ? req.logger : undefined;
-  const [number, regionCode, mask] = resolve(string, logger);
+  const [number, regionCode, countryCallingCode, mask] = resolve(string, logger);
   const raw = string.raw != null ? string.raw : string;
 
   let parts;
   if (number) {
-    parts = decompose(raw, number, regionCode, mask);
+    parts = decompose(raw, number, regionCode, countryCallingCode, mask);
     parts.type = type;
     parts.valid = parts.masked || phoneUtil.isValidNumber(number);
     return parts;
@@ -87,23 +80,18 @@ const resolve = function (string, logger) {
   string = string.replace(/[*]/g, '0');
 
   let number = null;
-  for (regionCode of supportedRegionCodes) {
-    try {
-      number = phoneUtil.parse(string, regionCode);
-    } catch (e) {
-      number = null;
-    }
-    if (number != null) { break; }
+  try {
+    number = phoneUtil.parse(string, 'US');
+  } catch (e) {
+    number = null;
   }
 
   if (number) {
     const countryCallingCode = number.getCountryCode();
-    if (countryCallingCode !== 1) {
-      regionCode = _.find(countryCodes, function (country) { return country.countryCodes.includes(countryCallingCode.toString()); }).isoCode2;
-    }
-    return [number, regionCode, mask];
+    regionCode = phoneUtil.getRegionCodeForCountryCode(countryCallingCode);
+    return [number, regionCode, countryCallingCode, mask];
   } else {
-    return [null, null, null];
+    return [null, null, null, null];
   }
 };
 
@@ -114,9 +102,8 @@ const asterisk = function (str, mask) {
   return str.split('').reverse().map(maskChar).reverse().join('');
 };
 
-const decompose = function (raw, number, regionCode, mask) {
+const decompose = function (raw, number, regionCode, countryCallingCode, mask) {
   let exchange, line, nationalDestinationCode;
-  const nationalPrefix = phoneUtil.getNddPrefixForRegion(regionCode, true);
   let nationalSignificantNumber = phoneUtil.getNationalSignificantNumber(number);
   const nationalDestinationCodeLength = phoneUtil.getLengthOfNationalDestinationCode(number);
 
@@ -156,7 +143,8 @@ const decompose = function (raw, number, regionCode, mask) {
     }
   }
 
-  if (['US', 'CA'].indexOf(regionCode) !== -1) {
+  // only applicable for numbers under the NANP
+  if (countryCallingCode === 1) {
     exchange = subscriberNumber.substring(0, 3);
     line = subscriberNumber.substring(3);
   }
@@ -167,7 +155,6 @@ const decompose = function (raw, number, regionCode, mask) {
       : raw;
 
   const phone = new String(normal);
-  phone.prefix = nationalPrefix;
   phone.raw = raw;
   phone.area = nationalDestinationCode;
   phone.exchange = exchange;
@@ -175,6 +162,7 @@ const decompose = function (raw, number, regionCode, mask) {
   phone.number = subscriberNumber;
   phone.extension = extension;
   phone.country_code = regionCode;
+  phone.country_calling_code = countryCallingCode;
   if (mask.indexOf(true) >= 0) { phone.masked = true; }
   phone.is_tollfree = tollFreeAreaCodes[phone.area] != null ? tollFreeAreaCodes[phone.area] : false;
   return phone;
@@ -187,7 +175,8 @@ const components = [
   { name: 'line', type: 'string', description: 'Line' },
   { name: 'number', type: 'string', description: 'Full number' },
   { name: 'extension', type: 'string', description: 'Extension' },
-  { name: 'country_code', type: 'string', description: 'Country code' },
+  { name: 'country_code', type: 'string', description: 'Two letter country code' },
+  { name: 'country_calling_code', type: 'number', description: 'Numeric country calling code' },
   { name: 'type', type: 'string', description: 'Number type: home, work, mobile' },
   { name: 'is_tollfree', type: 'boolean', description: `Whether the number is toll-free (${Object.keys(tollFreeAreaCodes).join(', ')})` }
 ];
@@ -195,7 +184,6 @@ const components = [
 module.exports = {
   parse,
   components,
-  countryCodes: supportedRegionCodes,
   maskable: false,
   operators: [
     'is equal to',

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@activeprospect/indexer": "^1.3.2",
     "@activeprospect/trustedform-cert-id": "^1.1.1",
     "chrono-node": "^2.6.3",
+    "country-calling-code": "^0.0.3",
     "domain-name-parser": "0.0.4",
     "email-addresses": "^1.1.1",
     "google-libphonenumber": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@activeprospect/indexer": "^1.3.2",
     "@activeprospect/trustedform-cert-id": "^1.1.1",
     "chrono-node": "^2.6.3",
-    "country-calling-code": "^0.0.3",
     "domain-name-parser": "0.0.4",
     "email-addresses": "^1.1.1",
     "google-libphonenumber": "^3.2.3",

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -29,7 +29,6 @@ describe('Examples', function () {
       index.expandExamples(this.field);
       assert.deepEqual(this.field.examples, [{
         normal: '5127881111',
-        prefix: '1',
         raw: '512-788-1111',
         area: '512',
         exchange: '788',
@@ -38,6 +37,7 @@ describe('Examples', function () {
         extension: null,
         is_tollfree: false,
         country_code: 'US',
+        country_calling_code: 1,
         type: null,
         valid: true
       }
@@ -51,7 +51,6 @@ describe('Examples', function () {
       index.expandExamples(this.field);
       assert.deepEqual(this.field.examples, [{
         normal: '5127881111',
-        prefix: '1',
         raw: '512-788-1111',
         area: '512',
         exchange: '788',
@@ -60,6 +59,7 @@ describe('Examples', function () {
         extension: null,
         is_tollfree: false,
         country_code: 'US',
+        country_calling_code: 1,
         type: null,
         valid: true
       }

--- a/test/phone.test.js
+++ b/test/phone.test.js
@@ -185,6 +185,11 @@ describe('Phone', function () {
     assert(phone.countryCodes.indexOf('GB') !== -1);
   });
 
+  it('should handle non-us numbers', function () {
+    const ph = phone.parse('+49 30 22610');
+    assert.equal(ph.country_code, 'DE');
+  });
+
   it('should parse mobile hint', function () {
     const ph = phone.parse('5127891111m');
     assert.equal(ph.raw, '5127891111');

--- a/test/phone.test.js
+++ b/test/phone.test.js
@@ -54,6 +54,7 @@ describe('Phone', function () {
     assert.equal(ph.line, '1111');
     assert.equal(ph.number, '7891111');
     assert.equal(ph.country_code, 'US');
+    assert.equal(ph.country_calling_code, 1);
     assert.isUndefined(ph.masked);
     assert.isFalse(ph.is_tollfree);
     assert.isTrue(ph.valid);
@@ -68,6 +69,7 @@ describe('Phone', function () {
     assert.equal(ph.line, '1212');
     assert.equal(ph.number, '5551212');
     assert.equal(ph.country_code, 'US');
+    assert.equal(ph.country_calling_code, 1);
     assert.isUndefined(ph.masked);
     assert.isTrue(ph.is_tollfree);
     assert.isTrue(ph.valid);
@@ -95,6 +97,7 @@ describe('Phone', function () {
     assert.equal(ph.line, '****');
     assert.equal(ph.number, '*******');
     assert.equal(ph.country_code, 'US');
+    assert.equal(ph.country_calling_code, 1);
     assert.isNull(ph.type);
     assert.isTrue(ph.masked);
     assert.isFalse(ph.is_tollfree);
@@ -110,6 +113,7 @@ describe('Phone', function () {
     assert.equal(ph.line, '**11');
     assert.equal(ph.number, '*****11');
     assert.equal(ph.country_code, 'US');
+    assert.equal(ph.country_calling_code, 1);
     assert.isNull(ph.type);
     assert.isTrue(ph.masked);
     assert.isFalse(ph.is_tollfree);
@@ -126,6 +130,7 @@ describe('Phone', function () {
     assert.equal(ph.number, '*******');
     assert.equal(ph.extension, '**');
     assert.equal(ph.country_code, 'US');
+    assert.equal(ph.country_calling_code, 1);
     assert.isNull(ph.type);
     assert.isTrue(ph.masked);
     assert.isFalse(ph.is_tollfree);
@@ -142,6 +147,7 @@ describe('Phone', function () {
     assert.equal(ph.number, '*******');
     assert.equal(ph.extension, '42');
     assert.equal(ph.country_code, 'US');
+    assert.equal(ph.country_calling_code, 1);
     assert.isNull(ph.type);
     assert.isTrue(ph.masked);
     assert.isFalse(ph.is_tollfree);
@@ -157,37 +163,25 @@ describe('Phone', function () {
     assert.equal(ph.line, '****');
     assert.equal(ph.number, '*******');
     assert.equal(ph.country_code, 'US');
+    assert.equal(ph.country_calling_code, 1);
     assert.isTrue(ph.masked);
     assert.isFalse(ph.is_tollfree);
     assert.isTrue(ph.valid);
   });
 
-  xit('should parse UK phone', function () {
-    const ph = phone.parse('7981-555555');
-    assert.equal(ph.valueOf(), '5127891111');
-    assert.equal(ph.raw, '5127891111');
-    assert.equal(ph.area, '512');
-    assert.equal(ph.exchange, '789');
-    assert.equal(ph.line, '1111');
-    assert.equal(ph.number, '7891111');
-    assert.equal(ph.country_code, 'US');
-  });
-
-  it('should support United States', function () {
-    assert(phone.countryCodes.indexOf('US') !== -1);
-  });
-
-  it('should support Canada', function () {
-    assert(phone.countryCodes.indexOf('CA') !== -1);
-  });
-
-  it('should support UK', function () {
-    assert(phone.countryCodes.indexOf('GB') !== -1);
-  });
-
-  it('should handle non-us numbers', function () {
+  it('should handle non-North American numbers', function () {
     const ph = phone.parse('+49 30 22610');
+    assert.equal(ph.valueOf(), '3022610');
+    assert.equal(ph.raw, '+49 30 22610');
+    assert.equal(ph.area, '30');
+    assert.isUndefined(ph.exchange);
+    assert.isUndefined(ph.line);
+    assert.equal(ph.number, '22610');
     assert.equal(ph.country_code, 'DE');
+    assert.equal(ph.country_calling_code, 49);
+    assert.isUndefined(ph.masked);
+    assert.isFalse(ph.is_tollfree);
+    assert.isTrue(ph.valid);
   });
 
   it('should parse mobile hint', function () {

--- a/test/phone.test.js
+++ b/test/phone.test.js
@@ -184,6 +184,20 @@ describe('Phone', function () {
     assert.isTrue(ph.valid);
   });
 
+  it('should correctly set country code for a variety of formats', function () {
+    const numbers = [
+      { number: '+44 1484 519892', country: 'GB' },
+      { number: '+82-2-2184-7000', country: 'KR' },
+      { number: '+7 495 287 20 00', country: 'RU' },
+      { number: '+20226140000', country: 'EG' }
+    ];
+    numbers.forEach(function (number) {
+      const ph = phone.parse(number.number);
+      assert.equal(ph.country_code, number.country);
+      assert.isTrue(ph.valid);
+    });
+  });
+
   it('should parse mobile hint', function () {
     const ph = phone.parse('5127891111m');
     assert.equal(ph.raw, '5127891111');


### PR DESCRIPTION
## Description of the change

- Updated phone number parsing to correctly set country code for non-North American numbers
- Now captures the numeric country calling code and exposes that as a new component of the phone type
- Removed some old, half-baked code that tried to handle Canadian and UK numbers but didn't actually work, including a test for UK numbers that was always skipped
- Removed the code which looked up and set the national dialing prefix for a number which was never actually exposed as a component of the phone type

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/75305/fix-phone-1-country-code-to-provide-the-correct-country-code-instead-of-us

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
